### PR TITLE
Sub Issue機能追加

### DIFF
--- a/.claude/commands/sdp/export-issues.md
+++ b/.claude/commands/sdp/export-issues.md
@@ -100,7 +100,9 @@ First, create a single main issue for the requirement:
 #### Issue Title
 Format: `[<slug>] <requirement title>`
 
-#### Issue Body
+#### Issue Body Template
+
+**For English (language: en)**:
 ```markdown
 ## Requirement Overview
 <brief summary from .sdp/<slug>/requirement.md Goal section>
@@ -122,6 +124,30 @@ See sub-issues below for detailed task breakdown.
 - [ ] Implementation started
 - [ ] Testing complete
 - [ ] Deployment ready
+```
+
+**For Japanese (language: ja)**:
+```markdown
+## 要件概要
+<brief summary from .sdp/<slug>/requirement.md Goal section>
+
+## 見積もりサマリー
+- 総タスク数: <count>
+- 予想時間: <expected_hours>h
+- 標準偏差: <stddev_hours>h
+- 信頼度: <confidence>
+
+## クリティカルパス
+<critical_path from rollup> (例: T-001 → T-003 → T-007)
+
+## タスク分解
+詳細なタスク分解はサブIssueを参照してください。
+
+## 進捗管理
+- [ ] 要件確定
+- [ ] 実装開始
+- [ ] テスト完了
+- [ ] デプロイ準備完了
 ```
 
 #### Labels
@@ -150,8 +176,9 @@ For each task in `.sdp/specs/<slug>/tasks.yml`, create a sub-issue using the `gh
 #### Sub-Issue Title
 Format: `[<slug>][T-xxx] <task.title>`
 
-#### Sub-Issue Body
-Include the following sections in markdown:
+#### Sub-Issue Body Template
+
+**For English (language: en)**:
 ```markdown
 ## Description
 <task.description>
@@ -173,6 +200,31 @@ Include the following sections in markdown:
 - Expected: <mean>h
 
 ## Risk Notes
+<task.risks if present>
+```
+
+**For Japanese (language: ja)**:
+```markdown
+## 説明
+<task.description>
+
+## 成果物
+<list of task.deliverables>
+
+## 完了の定義
+<checklist from task.dod>
+
+## 依存関係
+<list of task.depends_on with issue references if available>
+
+## 見積もり
+- 手法: PERT
+- 楽観値: <optimistic>h
+- 最頻値: <most_likely>h
+- 悲観値: <pessimistic>h
+- 期待値: <mean>h
+
+## リスクメモ
 <task.risks if present>
 ```
 
@@ -221,8 +273,9 @@ Create the output directory if it doesn't exist using Claude Code's file operati
 
 ### Step 3B: Generate Issue Drafts (Local Mode)
 
-Create a markdown file at `${OUT_DIR}/<slug>-issues.md` with the following structure:
+Create a markdown file at `${OUT_DIR}/<slug>-issues.md` with localized content based on `.sdp/config/language.yml`.
 
+**For English (language: en)**:
 ```markdown
 # GitHub Issues Draft for <slug>
 
@@ -257,12 +310,6 @@ See sub-issues below for detailed task breakdown.
 - [ ] Implementation started
 - [ ] Testing complete
 - [ ] Deployment ready
-
-## Tasks
-(This section will be populated after sub-issues are created)
-- [ ] #<sub-issue1> T-001: <task title> (<estimate>h)
-- [ ] #<sub-issue2> T-002: <task title> (<estimate>h)
-...
 ```
 
 **Labels**: <labels from export.yml github.labels + github.main_issue_labels (if set)>
@@ -309,6 +356,90 @@ See sub-issues below for detailed task breakdown.
 (Repeat for each task)
 
 ---
+```
+
+**For Japanese (language: ja)**:
+```markdown
+# <slug> GitHub Issues ドラフト
+
+この要件 <slug> のIssueドラフトです。
+構造: 1つのメインIssue + N個のサブIssue (タスク)
+
+---
+
+## メイン要件Issue
+
+**タイトル**: [<slug>] <requirement title>
+
+**本文**:
+```markdown
+## 要件概要
+<brief summary from .sdp/specs/<slug>/requirement.md Goal section>
+
+## 見積もりサマリー
+- 総タスク数: <count>
+- 予想時間: <expected_hours>h
+- 標準偏差: <stddev_hours>h
+- 信頼度: <confidence>
+
+## クリティカルパス
+<critical_path from rollup> (例: T-001 → T-003 → T-007)
+
+## タスク分解
+詳細なタスク分解はサブIssueを参照してください。
+
+## 進捗管理
+- [ ] 要件確定
+- [ ] 実装開始
+- [ ] テスト完了
+- [ ] デプロイ準備完了
+```
+
+**ラベル**: <labels from export.yml github.labels + github.main_issue_labels (if set)>
+
+---
+
+## タスクサブIssue
+
+### サブIssue 1: [T-001] <task title>
+
+**タイトル**: [T-001] <task.title>
+
+**本文**:
+```markdown
+## 説明
+<task.description>
+
+## 成果物
+- <deliverable 1>
+- <deliverable 2>
+
+## 完了の定義
+- [ ] <dod 1>
+- [ ] <dod 2>
+
+## 依存関係
+- <depends_on with issue references>
+
+## 見積もり
+- 手法: PERT
+- 楽観値: <optimistic>h
+- 最頻値: <most_likely>h
+- 悲観値: <pessimistic>h
+- 期待値: <mean>h
+
+## リスクメモ
+<task.risks if present>
+```
+
+**ラベル**: <labels from export.yml github.labels + github.task_labels (if set)>
+
+---
+
+(各タスクについて繰り返し)
+
+---
+```
 
 ## Instructions for Manual Issue Creation
 

--- a/.claude/commands/sdp/export-issues.md
+++ b/.claude/commands/sdp/export-issues.md
@@ -150,13 +150,6 @@ See sub-issues below for detailed task breakdown.
 - [ ] デプロイ準備完了
 ```
 
-#### Labels
-Combine the following (only if set in export.yml):
-- `github.labels` (default labels for all issues)
-- `github.main_issue_labels` (if set, additional labels for main issues)
-
-**Note**: Do NOT add "requirement" or any hardcoded label automatically. Only use labels from export.yml configuration.
-
 #### Execution
 ```bash
 # Combine labels from export.yml (labels + main_issue_labels if set)
@@ -227,13 +220,6 @@ Format: `[<slug>][T-xxx] <task.title>`
 ## リスクメモ
 <task.risks if present>
 ```
-
-#### Labels
-Combine the following (only if set):
-- `github.labels` (default labels for all issues)
-- `github.task_labels` (if set, additional labels for task sub-issues)
-
-**Note**: Do NOT add "task" or any hardcoded label automatically. Only use labels from export.yml configuration.
 
 #### Execution
 Use `gh sub-issue create` to create sub-issues that are automatically linked to the parent:
@@ -312,8 +298,6 @@ See sub-issues below for detailed task breakdown.
 - [ ] Deployment ready
 ```
 
-**Labels**: <labels from export.yml github.labels + github.main_issue_labels (if set)>
-
 ---
 
 ## Task Sub-Issues
@@ -348,8 +332,6 @@ See sub-issues below for detailed task breakdown.
 ## Risk Notes
 <task.risks if present>
 ```
-
-**Labels**: <labels from export.yml github.labels + github.task_labels (if set)>
 
 ---
 
@@ -395,8 +377,6 @@ See sub-issues below for detailed task breakdown.
 - [ ] デプロイ準備完了
 ```
 
-**ラベル**: <labels from export.yml github.labels + github.main_issue_labels (if set)>
-
 ---
 
 ## タスクサブIssue
@@ -431,8 +411,6 @@ See sub-issues below for detailed task breakdown.
 ## リスクメモ
 <task.risks if present>
 ```
-
-**ラベル**: <labels from export.yml github.labels + github.task_labels (if set)>
 
 ---
 

--- a/.sdp/config/export.yml
+++ b/.sdp/config/export.yml
@@ -12,6 +12,11 @@ github:
   # If not specified, gh CLI will auto-detect from current git repository
   repo: your-org/your-repo
 
+  # Use GitHub's sub-issue feature (requires gh sub-issue extension)
+  # - true: Create tasks as sub-issues with automatic parent-child relationship
+  # - false: Create tasks as regular issues and link them manually to parent
+  sub_issue_mode: false
+
   # Default labels to apply to all issues
   # These labels will be added to both main requirement issues and task sub-issues
   labels:

--- a/bin/sdp.js
+++ b/bin/sdp.js
@@ -189,21 +189,6 @@ language: ${lang}
     });
     success('.sdp/ directory structure created');
 
-    // Add .gitignore for .sdp if it doesn't exist
-    const gitignorePath = path.join(targetDir, '.gitignore');
-    let gitignoreContent = '';
-
-    if (fs.existsSync(gitignorePath)) {
-      gitignoreContent = fs.readFileSync(gitignorePath, 'utf8');
-    }
-
-    if (!gitignoreContent.includes('.sdp/')) {
-      info('📝 Updating .gitignore...');
-      const sdpIgnore = '\n# Spec-Driven Planning outputs\n.sdp/\n';
-      fs.appendFileSync(gitignorePath, sdpIgnore);
-      success('.gitignore updated');
-    }
-
     log('\n╔═══════════════════════════════════════════════════════════╗', colors.bright + colors.green);
     log('║                                                           ║', colors.bright + colors.green);
     log('║   🎉 Setup Complete!                                     ║', colors.bright + colors.green);


### PR DESCRIPTION
This pull request updates the `.claude/commands/sdp/export-issues.md` documentation and the `.sdp/config/export.yml` configuration to add support for a new `sub_issue_mode` setting, enabling the use of GitHub's sub-issue feature for task breakdown exports. It also introduces improved localization (English/Japanese) for issue templates, clarifies configuration and instructions, and refines the export process for both GitHub and local markdown outputs.

**Key changes:**

### Sub-issue Mode Support and Configuration
- Added `github.sub_issue_mode` to `.sdp/config/export.yml` and documented its usage, allowing users to choose between GitHub sub-issues (automatic parent-child linking) and regular issues with manual linking. [[1]](diffhunk://#diff-31ef61036d08bbed16ec1c37b34ffc1d1700cb39e6d5a96e29cb02613249081aL2-R7) [[2]](diffhunk://#diff-31ef61036d08bbed16ec1c37b34ffc1d1700cb39e6d5a96e29cb02613249081aR58) [[3]](diffhunk://#diff-48b771c635b61b86ee0925effdc75d73de5b63d0840540f30077cef7a4153c3bR15-R19)
- Updated instructions to check for the `gh sub-issue` CLI extension and provide installation guidance if missing. [[1]](diffhunk://#diff-31ef61036d08bbed16ec1c37b34ffc1d1700cb39e6d5a96e29cb02613249081aR84-R92) [[2]](diffhunk://#diff-31ef61036d08bbed16ec1c37b34ffc1d1700cb39e6d5a96e29cb02613249081aR616-R629)

### Localization and Template Improvements
- Introduced localized (English and Japanese) templates for both main and sub-issue bodies, including estimation summaries, critical path, and task breakdowns. [[1]](diffhunk://#diff-31ef61036d08bbed16ec1c37b34ffc1d1700cb39e6d5a96e29cb02613249081aL97-R111) [[2]](diffhunk://#diff-31ef61036d08bbed16ec1c37b34ffc1d1700cb39e6d5a96e29cb02613249081aL121-R157) [[3]](diffhunk://#diff-31ef61036d08bbed16ec1c37b34ffc1d1700cb39e6d5a96e29cb02613249081aL176-R294) [[4]](diffhunk://#diff-31ef61036d08bbed16ec1c37b34ffc1d1700cb39e6d5a96e29cb02613249081aL324-R489)

### Export Process Enhancements
- Clarified and separated export logic for sub-issue mode (`github.sub_issue_mode: true`) vs. regular issue mode (`false`), including corresponding shell command examples and checklist management. [[1]](diffhunk://#diff-31ef61036d08bbed16ec1c37b34ffc1d1700cb39e6d5a96e29cb02613249081aL140-R183) [[2]](diffhunk://#diff-31ef61036d08bbed16ec1c37b34ffc1d1700cb39e6d5a96e29cb02613249081aL225-R306) [[3]](diffhunk://#diff-31ef61036d08bbed16ec1c37b34ffc1d1700cb39e6d5a96e29cb02613249081aL346-R547)
- Improved local markdown export to support localized content and updated structure for main and sub-issues. [[1]](diffhunk://#diff-31ef61036d08bbed16ec1c37b34ffc1d1700cb39e6d5a96e29cb02613249081aL240-R319) [[2]](diffhunk://#diff-31ef61036d08bbed16ec1c37b34ffc1d1700cb39e6d5a96e29cb02613249081aL276-L298)

### Usability and Error Handling
- Added explicit error messages and user guidance for missing authentication, missing `gh` CLI, or missing `gh sub-issue` extension, with localized output where appropriate. [[1]](diffhunk://#diff-31ef61036d08bbed16ec1c37b34ffc1d1700cb39e6d5a96e29cb02613249081aR84-R92) [[2]](diffhunk://#diff-31ef61036d08bbed16ec1c37b34ffc1d1700cb39e6d5a96e29cb02613249081aR616-R629)

### Configuration and Label Handling
- Clarified label application rules: only labels specified in `export.yml` are used; no hardcoded labels are added automatically. [[1]](diffhunk://#diff-31ef61036d08bbed16ec1c37b34ffc1d1700cb39e6d5a96e29cb02613249081aL121-R157) [[2]](diffhunk://#diff-31ef61036d08bbed16ec1c37b34ffc1d1700cb39e6d5a96e29cb02613249081aL176-R294)

These changes significantly improve flexibility, localization, and clarity for exporting task breakdowns as GitHub issues or local markdown drafts.