### PR TITLE
Backlog出力を追加

### DIFF
--- a/.claude/commands/sdp/export-issues.md
+++ b/.claude/commands/sdp/export-issues.md
@@ -57,6 +57,7 @@ Read `.sdp/config/export.yml` to determine:
 Based on the `destination` field in export.yml:
 - **`github`**: Export to GitHub Issues (requires `gh` CLI)
 - **`jira`**: Export to Jira Issues (uses REST API v3)
+- **`backlog`**: Export to Backlog Issues (uses REST API v2)
 - **`local`**: Export to local markdown files (no external tools required)
 
 ### Implementation Details
@@ -64,6 +65,7 @@ Based on the `destination` field in export.yml:
 For detailed implementation instructions, refer to:
 - **GitHub mode**: `.sdp/docs/export-github.md`
 - **Jira mode**: `.sdp/docs/export-jira.md`
+- **Backlog mode**: `.sdp/docs/export-backlog.md`
 - **Local mode**: `.sdp/docs/export-local.md`
 
 ## Step 3: Execute Export
@@ -87,6 +89,17 @@ If `destination: jira`, read `.sdp/docs/export-jira.md` for complete implementat
 1. Check Jira configuration (url, email, project, API token)
 2. Load templates and convert Wiki Markup to ADF
 3. Create main issue via REST API
+4. Create task issues if using sub_tasks or linked_issues mode
+5. Generate console output with issue URLs
+
+### Backlog Export
+
+If `destination: backlog`, read `.sdp/docs/export-backlog.md` for complete implementation details.
+
+**Summary**:
+1. Check Backlog configuration (space_key, project_key, API key)
+2. Get project ID and issue type IDs via REST API
+3. Create main issue with Markdown description
 4. Create task issues if using sub_tasks or linked_issues mode
 5. Generate console output with issue URLs
 
@@ -278,6 +291,7 @@ Collect the returned issue number and URL for each task.
 For detailed implementation guides on each export mode, refer to:
 - **GitHub Issues**: `.sdp/docs/export-github.md`
 - **Jira Issues**: `.sdp/docs/export-jira.md`
+- **Backlog Issues**: `.sdp/docs/export-backlog.md`
 - **Local Files**: `.sdp/docs/export-local.md`
 
 These files contain complete API reference, template formats, error handling, and manual import instructions.

--- a/.sdp/config/export.yml
+++ b/.sdp/config/export.yml
@@ -1,10 +1,11 @@
 # Export Configuration for /sdp:export-issues command
 # Determines where task breakdowns should be exported
 
-# Export destination: "github", "jira", or "local"
-# - github: Create issues directly in GitHub (requires gh CLI)
-# - jira:   Create issues directly in Jira (requires jira CLI)
-# - local:  Generate markdown files locally
+# Export destination: "github", "jira", "backlog", or "local"
+# - github:  Create issues directly in GitHub (requires gh CLI)
+# - jira:    Create issues directly in Jira (uses REST API v3)
+# - backlog: Create issues directly in Backlog (uses REST API v2)
+# - local:   Generate markdown files locally
 destination: github
 
 # GitHub export settings
@@ -79,6 +80,41 @@ jira:
   labels:
   #  - sdp
   #  - planning
+
+# Backlog export settings
+backlog:
+  # Backlog space key (subdomain)
+  # e.g., if your URL is https://myspace.backlog.jp, space_key is "myspace"
+  space_key: myspace
+
+  # Backlog domain (default: backlog.jp for Japanese instances)
+  # Use "backlog.com" for international instances
+  domain: backlog.jp
+
+  # Backlog project key (shown in project settings)
+  project_key: PROJ
+
+  # Authentication: Use API key (recommended) or set as environment variable
+  # Create API key at: 個人設定 > API > 登録
+  # https://support-ja.backlog.com/hc/ja/articles/115015420567-API%E3%81%AE%E8%A8%AD%E5%AE%9A
+  # Option 1: Set API key directly (not recommended for security)
+  # api_key: your-api-key-here
+  # Option 2: Use environment variable (recommended)
+  # Set environment variable: export BACKLOG_API_KEY=your-api-key-here
+  # The command will read from environment variable if api_key is not set
+
+  # Issue export mode
+  # - "sub_tasks": Create tasks as sub-tasks (Backlog native parent-child)
+  # - "linked_issues": Create tasks as regular issues and link via comments
+  # - "single_issue": Create one issue with all tasks as checkboxes
+  issue_mode: sub_tasks
+
+  # Backlog issue type for main requirement (e.g., "タスク", "バグ", "要望")
+  main_issue_type: タスク
+
+  # Backlog issue type for task issues (e.g., "タスク", "バグ")
+  # Only used when issue_mode is "sub_tasks" or "linked_issues"
+  task_issue_type: タスク
 
 # Local export settings
 local:

--- a/.sdp/config/export.yml
+++ b/.sdp/config/export.yml
@@ -84,12 +84,12 @@ jira:
 # Backlog export settings
 backlog:
   # Backlog space key (subdomain)
-  # e.g., if your URL is https://myspace.backlog.jp, space_key is "myspace"
+  # e.g., if your URL is https://myspace.backlog.com, space_key is "myspace"
   space_key: myspace
 
-  # Backlog domain (default: backlog.jp for Japanese instances)
-  # Use "backlog.com" for international instances
-  domain: backlog.jp
+  # Backlog domain (default: backlog.com for international instances)
+  # Use "backlog.jp" for Japanese instances
+  domain: backlog.com
 
   # Backlog project key (shown in project settings)
   project_key: PROJ
@@ -107,7 +107,7 @@ backlog:
   # - "sub_tasks": Create tasks as sub-tasks (Backlog native parent-child)
   # - "linked_issues": Create tasks as regular issues and link via comments
   # - "single_issue": Create one issue with all tasks as checkboxes
-  issue_mode: sub_tasks
+  issue_mode: single_issue
 
   # Backlog issue type for main requirement (e.g., "タスク", "バグ", "要望")
   main_issue_type: タスク

--- a/.sdp/docs/export-backlog.md
+++ b/.sdp/docs/export-backlog.md
@@ -1,0 +1,562 @@
+# Backlog Export Implementation Guide
+
+Complete implementation guide for exporting task breakdowns to Backlog Issues using REST API v2.
+
+## Overview
+
+This guide covers:
+- Pre-check requirements for Backlog mode
+- Configuration loading
+- Main issue creation via REST API
+- Task issue creation (sub-tasks or linked issues)
+- Error handling and output format
+
+## Pre-Check for Backlog Mode
+
+Claude Code will check:
+- If required Backlog configuration is present in `.sdp/config/export.yml`:
+  - `backlog.space_key`: Backlog space key (e.g., "MYSPACE")
+  - `backlog.project_key`: Project key (e.g., "PROJ")
+  - `backlog.api_key`: API key for authentication
+- If API key is available:
+  - Check if `backlog.api_key` is set in config, OR
+  - Check if `BACKLOG_API_KEY` environment variable is set
+
+If required configuration is missing, display an error with setup instructions.
+
+**Note**: This implementation uses Backlog REST API v2 with API key authentication.
+
+**API Documentation**: https://developer.nulab.com/docs/backlog/
+
+## Step 1: Load Backlog Configuration
+
+Read Backlog settings from `.sdp/config/export.yml`:
+
+```yaml
+backlog:
+  space_key: myspace                    # Backlog space key (subdomain)
+  project_key: PROJ                     # Project key
+  api_key: your-api-key                 # API key (or use environment variable)
+  issue_mode: sub_tasks                 # "sub_tasks", "linked_issues", or "single_issue"
+  main_issue_type: Task                 # Issue type for main issue (Task, Bug, etc.)
+  task_issue_type: Task                 # Issue type for task issues
+```
+
+Get API key:
+```bash
+# Priority 1: From config file
+API_KEY="${BACKLOG_API_KEY_FROM_CONFIG}"
+
+# Priority 2: From environment variable
+if [ -z "$API_KEY" ]; then
+  API_KEY="${BACKLOG_API_KEY}"
+fi
+```
+
+Construct base URL:
+```bash
+BACKLOG_URL="https://${SPACE_KEY}.backlog.com"
+# or for jp domain:
+BACKLOG_URL="https://${SPACE_KEY}.backlog.jp"
+```
+
+## Step 2: Get Project ID and Issue Type IDs
+
+Before creating issues, retrieve the project ID and issue type IDs:
+
+### Get Project ID
+
+```bash
+# Get project information
+PROJECT_RESPONSE=$(curl -s -X GET \
+  "${BACKLOG_URL}/api/v2/projects/${PROJECT_KEY}?apiKey=${API_KEY}")
+
+# Extract project ID
+PROJECT_ID=$(echo "${PROJECT_RESPONSE}" | jq -r '.id')
+```
+
+### Get Issue Type IDs
+
+```bash
+# Get issue types for the project
+ISSUE_TYPES_RESPONSE=$(curl -s -X GET \
+  "${BACKLOG_URL}/api/v2/projects/${PROJECT_ID}/issueTypes?apiKey=${API_KEY}")
+
+# Extract main issue type ID
+MAIN_ISSUE_TYPE_ID=$(echo "${ISSUE_TYPES_RESPONSE}" | jq -r ".[] | select(.name==\"${MAIN_ISSUE_TYPE}\") | .id")
+
+# Extract task issue type ID
+TASK_ISSUE_TYPE_ID=$(echo "${ISSUE_TYPES_RESPONSE}" | jq -r ".[] | select(.name==\"${TASK_ISSUE_TYPE}\") | .id")
+```
+
+## Step 3: Create Main Issue (Backlog Mode)
+
+The content and structure depend on `backlog.issue_mode`.
+
+### Issue Summary (Title)
+Format: `[<slug>] <requirement title>`
+
+### Issue Description Template
+
+**For all modes**, use the same template structure as GitHub/Jira but with Backlog Markdown syntax.
+
+Backlog supports Markdown with some extensions:
+- Headings: `# H1`, `## H2`, etc.
+- Bold: `**bold**` or `__bold__`
+- Lists: `- item` or `* item`
+- Checkboxes: `- [ ] unchecked` or `- [x] checked`
+- Links: `[text](url)`
+- Code blocks: ` ```language ... ``` `
+
+**Template Structure**:
+
+```markdown
+## 要件概要
+
+{{requirement_summary}}
+
+---
+
+## タスク分解
+
+{{task_list}}
+
+---
+
+## 見積もり
+
+- **タスク数**: {{task_count}}
+- **期待工数**: {{expected_hours}}h
+- **標準偏差**: ±{{stddev_hours}}h
+- **信頼度**: {{confidence}}
+
+---
+
+## クリティカルパス
+
+{{critical_path}}
+```
+
+### Execution
+
+Use Backlog REST API v2 to create the issue:
+
+```bash
+# Prepare issue data
+ISSUE_DATA=$(cat <<EOF
+{
+  "projectId": ${PROJECT_ID},
+  "summary": "[${SLUG}] ${REQUIREMENT_TITLE}",
+  "description": "${DESCRIPTION}",
+  "issueTypeId": ${MAIN_ISSUE_TYPE_ID},
+  "priorityId": 3
+}
+EOF
+)
+
+# Create main issue
+RESPONSE=$(curl -s -X POST \
+  "${BACKLOG_URL}/api/v2/issues?apiKey=${API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d "${ISSUE_DATA}")
+
+# Extract issue ID and issue key
+MAIN_ISSUE_ID=$(echo "${RESPONSE}" | jq -r '.id')
+MAIN_ISSUE_KEY=$(echo "${RESPONSE}" | jq -r '.issueKey')
+```
+
+**If `issue_mode: single_issue`**: This is the only issue created. Skip to Step 5.
+
+**If `issue_mode: sub_tasks` or `issue_mode: linked_issues`**: Collect the main issue ID for use in creating task issues (proceed to Step 4).
+
+## Step 4: Create Task Issues (Backlog Mode)
+
+**Note**: This step is only executed if `issue_mode` is `sub_tasks` or `linked_issues`. Skip this step if `issue_mode: single_issue`.
+
+For each task in `.sdp/specs/<slug>/tasks.yml`, create an issue.
+
+### Task Issue Summary (Title)
+Format: `[T-xxx] <task.title>`
+
+### Task Issue Description
+
+```markdown
+## タスク詳細
+
+- **タスクID**: {{task.id}}
+- **見積もり**: {{task.estimate.optimistic}}h / {{task.estimate.most_likely}}h / {{task.estimate.pessimistic}}h (期待値: {{task.estimate.mean}}h)
+
+---
+
+## 説明
+
+{{task.description}}
+
+---
+
+## 成果物
+
+{{#task.deliverables}}
+- {{deliverable}}
+{{/task.deliverables}}
+
+---
+
+## 完了条件 (DoD)
+
+{{#task.dod}}
+- [ ] {{item}}
+{{/task.dod}}
+
+---
+
+## 依存関係
+
+{{#task.dependencies}}
+- {{dependency}}
+{{/task.dependencies}}
+```
+
+### Execution
+
+**If `issue_mode: sub_tasks`**:
+
+Backlog supports parent-child relationships natively:
+
+```bash
+# Prepare task data with parent issue
+TASK_DATA=$(cat <<EOF
+{
+  "projectId": ${PROJECT_ID},
+  "summary": "[${TASK_ID}] ${TASK_TITLE}",
+  "description": "${TASK_DESCRIPTION}",
+  "issueTypeId": ${TASK_ISSUE_TYPE_ID},
+  "priorityId": 3,
+  "parentIssueId": ${MAIN_ISSUE_ID}
+}
+EOF
+)
+
+# Create sub-task
+RESPONSE=$(curl -s -X POST \
+  "${BACKLOG_URL}/api/v2/issues?apiKey=${API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d "${TASK_DATA}")
+
+# Extract task issue ID and key
+TASK_ISSUE_ID=$(echo "${RESPONSE}" | jq -r '.id')
+TASK_ISSUE_KEY=$(echo "${RESPONSE}" | jq -r '.issueKey')
+```
+
+**If `issue_mode: linked_issues`**:
+
+Create regular issues without parent, then add a comment to link them:
+
+```bash
+# Create regular task issue (without parentIssueId)
+TASK_DATA=$(cat <<EOF
+{
+  "projectId": ${PROJECT_ID},
+  "summary": "[${TASK_ID}] ${TASK_TITLE}",
+  "description": "${TASK_DESCRIPTION}",
+  "issueTypeId": ${TASK_ISSUE_TYPE_ID},
+  "priorityId": 3
+}
+EOF
+)
+
+RESPONSE=$(curl -s -X POST \
+  "${BACKLOG_URL}/api/v2/issues?apiKey=${API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d "${TASK_DATA}")
+
+TASK_ISSUE_ID=$(echo "${RESPONSE}" | jq -r '.id')
+TASK_ISSUE_KEY=$(echo "${RESPONSE}" | jq -r '.issueKey')
+
+# Add a comment to the main issue linking to this task
+COMMENT_DATA=$(cat <<EOF
+{
+  "content": "関連タスク: ${TASK_ISSUE_KEY} - ${TASK_TITLE}"
+}
+EOF
+)
+
+curl -s -X POST \
+  "${BACKLOG_URL}/api/v2/issues/${MAIN_ISSUE_ID}/comments?apiKey=${API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d "${COMMENT_DATA}"
+```
+
+Collect the returned issue key and URL for each task.
+
+## Step 5: Finalize and Collect Results (Backlog Mode)
+
+**If `issue_mode: single_issue`**:
+- All tasks are already included in the single issue as checkboxes
+- No additional updates needed
+- Create a summary for console output showing the single issue URL
+
+**If `issue_mode: sub_tasks`**:
+- Backlog automatically maintains the parent-child relationship
+- Sub-tasks are visible in the parent issue
+- No manual update needed
+
+**If `issue_mode: linked_issues`**:
+- Issues are linked via comments
+- You can optionally update the main issue description with a task list
+
+Create a mapping table of task ID → issue key/URL and main issue for the console output.
+
+## Output Format
+
+The console output after successful export will display:
+
+### Success Output (Japanese)
+
+**Single Issue Mode**:
+```
+✓ Backlog Issueへのエクスポートが完了しました
+
+作成されたIssue:
+- Main Issue: PROJ-123 [US-001] User Registration Feature
+  https://myspace.backlog.jp/view/PROJ-123
+
+すべてのタスク (3件) は単一のIssue内にチェックボックスとして含まれています。
+```
+
+**Sub-Tasks Mode**:
+```
+✓ Backlog Issueへのエクスポートが完了しました
+
+作成されたIssue:
+- Main Issue: PROJ-123 [US-001] User Registration Feature
+  https://myspace.backlog.jp/view/PROJ-123
+
+タスクIssue (3件):
+- PROJ-124 [T-001] Set up database schema (3h)
+  https://myspace.backlog.jp/view/PROJ-124
+- PROJ-125 [T-002] Implement authentication API (5h)
+  https://myspace.backlog.jp/view/PROJ-125
+- PROJ-126 [T-003] Create user registration UI (4h)
+  https://myspace.backlog.jp/view/PROJ-126
+
+タスクはMain Issueのsub-taskとして作成されています。
+```
+
+**Linked Issues Mode**:
+```
+✓ Backlog Issueへのエクスポートが完了しました
+
+作成されたIssue:
+- Main Issue: PROJ-123 [US-001] User Registration Feature
+  https://myspace.backlog.jp/view/PROJ-123
+
+タスクIssue (3件):
+- PROJ-124 [T-001] Set up database schema (3h)
+  https://myspace.backlog.jp/view/PROJ-124
+- PROJ-125 [T-002] Implement authentication API (5h)
+  https://myspace.backlog.jp/view/PROJ-125
+- PROJ-126 [T-003] Create user registration UI (4h)
+  https://myspace.backlog.jp/view/PROJ-126
+
+タスクはコメントでMain Issueにリンクされています。
+```
+
+## Error Cases
+
+### Backlog Configuration Incomplete
+
+```
+❌ エラー: Backlog設定が不完全です
+
+以下の設定を `.sdp/config/export.yml` と環境変数で設定してください:
+
+不足している設定:
+- backlog.space_key (e.g., "myspace")
+- backlog.project_key (e.g., "PROJ")
+- BACKLOG_API_KEY (環境変数)
+
+Backlog APIキーの取得方法:
+  1. Backlogにログイン
+  2. 個人設定 > APIを開く
+  3. 「登録」をクリックしてAPIキーを生成
+  https://support-ja.backlog.com/hc/ja/articles/115015420567-API%E3%81%AE%E8%A8%AD%E5%AE%9A
+
+環境変数の設定:
+  export BACKLOG_API_KEY=<your-api-key>
+
+設定後、再度エクスポートを実行してください。
+```
+
+### Backlog API Key Not Set
+
+```
+❌ エラー: Backlog APIキーが設定されていません
+
+環境変数 BACKLOG_API_KEY を設定してください。
+
+Backlog APIキーの取得方法:
+  1. Backlogにログイン
+  2. 個人設定 > APIを開く
+  3. 「登録」をクリックしてAPIキーを生成
+  https://support-ja.backlog.com/hc/ja/articles/115015420567-API%E3%81%AE%E8%A8%AD%E5%AE%9A
+
+環境変数の設定:
+  export BACKLOG_API_KEY=<your-api-key>
+
+設定後、再度エクスポートを実行してください。
+```
+
+### Project Not Found
+
+```
+❌ エラー: Backlog プロジェクトが見つかりません
+
+プロジェクトキー "${PROJECT_KEY}" が存在しないか、アクセス権限がありません。
+
+確認事項:
+1. プロジェクトキーが正しいか確認してください
+2. APIキーに該当プロジェクトへのアクセス権限があるか確認してください
+3. space_keyが正しいか確認してください
+
+設定を修正後、再度エクスポートを実行してください。
+```
+
+## Manual Issue Creation Instructions
+
+### Prerequisites
+
+**For Backlog**:
+- Create Backlog API key: 個人設定 > API > 登録
+- Configure `.sdp/config/export.yml`:
+  - Set `backlog.space_key` (your Backlog space subdomain)
+  - Set `backlog.project_key` (project key shown in project settings)
+- Set API key as environment variable: `export BACKLOG_API_KEY=your-key`
+
+### Option A: Single Issue Mode
+
+```bash
+# Set up variables
+BACKLOG_URL="https://myspace.backlog.jp"
+PROJECT_KEY="PROJ"
+API_KEY="${BACKLOG_API_KEY}"
+
+# Get project ID
+PROJECT_ID=$(curl -s "${BACKLOG_URL}/api/v2/projects/${PROJECT_KEY}?apiKey=${API_KEY}" | jq -r '.id')
+
+# Get issue type ID
+ISSUE_TYPE_ID=$(curl -s "${BACKLOG_URL}/api/v2/projects/${PROJECT_ID}/issueTypes?apiKey=${API_KEY}" | jq -r '.[0].id')
+
+# Create issue
+curl -X POST "${BACKLOG_URL}/api/v2/issues?apiKey=${API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "projectId": '${PROJECT_ID}',
+    "summary": "[slug] Title",
+    "description": "## 要件概要\n...",
+    "issueTypeId": '${ISSUE_TYPE_ID}',
+    "priorityId": 3
+  }'
+```
+
+### Option B: Sub-Task Mode
+
+```bash
+# Create main issue (same as Option A)
+MAIN_ISSUE_ID=$(curl -s -X POST "${BACKLOG_URL}/api/v2/issues?apiKey=${API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{...}' | jq -r '.id')
+
+# Create sub-task with parent
+curl -X POST "${BACKLOG_URL}/api/v2/issues?apiKey=${API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "projectId": '${PROJECT_ID}',
+    "summary": "[T-001] Task title",
+    "description": "## タスク詳細\n...",
+    "issueTypeId": '${ISSUE_TYPE_ID}',
+    "priorityId": 3,
+    "parentIssueId": '${MAIN_ISSUE_ID}'
+  }'
+```
+
+### Option C: Linked Issues Mode
+
+```bash
+# Create main issue (same as Option A)
+
+# Create task issue without parent
+TASK_ISSUE_ID=$(curl -s -X POST "${BACKLOG_URL}/api/v2/issues?apiKey=${API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "projectId": '${PROJECT_ID}',
+    "summary": "[T-001] Task title",
+    "description": "## タスク詳細\n...",
+    "issueTypeId": '${ISSUE_TYPE_ID}',
+    "priorityId": 3
+  }' | jq -r '.id')
+
+# Add comment to link
+curl -X POST "${BACKLOG_URL}/api/v2/issues/${MAIN_ISSUE_ID}/comments?apiKey=${API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "content": "関連タスク: PROJ-124 - Task title"
+  }'
+```
+
+## API Reference
+
+### Get Project
+
+```
+GET /api/v2/projects/:projectKey?apiKey=:apiKey
+```
+
+Returns project information including project ID.
+
+### Get Issue Types
+
+```
+GET /api/v2/projects/:projectId/issueTypes?apiKey=:apiKey
+```
+
+Returns list of issue types for the project.
+
+### Create Issue
+
+```
+POST /api/v2/issues?apiKey=:apiKey
+Content-Type: application/json
+
+{
+  "projectId": 123,
+  "summary": "Issue title",
+  "description": "Issue description (Markdown)",
+  "issueTypeId": 456,
+  "priorityId": 3,
+  "parentIssueId": 789  // Optional: for sub-tasks
+}
+```
+
+Returns created issue with `id`, `issueKey`, and other properties.
+
+### Add Comment
+
+```
+POST /api/v2/issues/:issueId/comments?apiKey=:apiKey
+Content-Type: application/json
+
+{
+  "content": "Comment text (Markdown)"
+}
+```
+
+Adds a comment to the specified issue.
+
+## Notes
+
+- **Markdown Support**: Backlog supports standard Markdown syntax including checkboxes
+- **Priority IDs**: 2=High, 3=Normal, 4=Low (adjust as needed)
+- **API Rate Limits**: Backlog has rate limits; check documentation for details
+- **Domain**: Use `.backlog.jp` for Japanese instances or `.backlog.com` for international
+- **Authentication**: API key is passed as query parameter `?apiKey=xxx`


### PR DESCRIPTION
This pull request adds support for exporting tasks to Backlog (in addition to GitHub, Jira, and local files) and updates documentation and configuration accordingly. It introduces new configuration options for Backlog, explains the new export mode in both English and Japanese documentation, and clarifies the available export destinations and issue organization modes.

**Export destination and configuration enhancements:**

* Added `backlog` as a supported export destination in `.sdp/config/export.yml`, with detailed configuration options for Backlog (space key, domain, project key, API key, issue mode, and issue types). [[1]](diffhunk://#diff-48b771c635b61b86ee0925effdc75d73de5b63d0840540f30077cef7a4153c3bL4-R7) [[2]](diffhunk://#diff-48b771c635b61b86ee0925effdc75d73de5b63d0840540f30077cef7a4153c3bR84-R118)
* Updated documentation to describe Backlog export settings and requirements, including how to set up authentication and project information. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L54-R70) [[2]](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336L52-R68)

**Documentation updates (English and Japanese):**

* Updated both `README.md` and `README.ja.md` to reflect multi-platform export support (GitHub, Jira, Backlog, local), including new summary sections, quick start guides, and export instructions for each platform. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L12-R12) [[2]](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336L10-R10) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L149-R250) [[4]](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336L147-R160) [[5]](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336L164-R245)
* Added explanations of the three issue organization modes (`sub_issues`/`sub_tasks`, `linked_issues`, `single_issue`) and how they apply to each export destination. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L149-R250) [[2]](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336L164-R245)
* Updated requirements sections to explain optional dependencies for each export mode (GitHub CLI, Jira API token, Backlog API key). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L271-R340) [[2]](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336L269-R342)

**Command and implementation documentation:**

* Updated `.claude/commands/sdp/export-issues.md` to include Backlog as a destination, with implementation details and references to a new `.sdp/docs/export-backlog.md` guide. [[1]](diffhunk://#diff-31ef61036d08bbed16ec1c37b34ffc1d1700cb39e6d5a96e29cb02613249081aR60-R68) [[2]](diffhunk://#diff-31ef61036d08bbed16ec1c37b34ffc1d1700cb39e6d5a96e29cb02613249081aR95-R105) [[3]](diffhunk://#diff-31ef61036d08bbed16ec1c37b34ffc1d1700cb39e6d5a96e29cb02613249081aR294)
* Updated command summary tables in both English and Japanese READMEs to include all supported export destinations. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L208-R264) [[2]](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336L206-R263)