### PR TITLE
show-planからNext Stepを削除

### DIFF
--- a/.claude/commands/sdp/show-plan.md
+++ b/.claude/commands/sdp/show-plan.md
@@ -75,19 +75,12 @@ Based on confidence level and stddev:
 - **Resource buffer**: Key areas needing backup capacity
 - **Risk buffer**: Contingency for high-risk tasks
 
-### 7. Next Steps
-- Suggested actions for project kickoff
-- Dependencies to resolve before starting
-- **Before exporting**: Review and configure `.sdp/config/export.yml`:
-  - Set `destination` to `github` or `local`
-  - Configure repository (for GitHub)
-  - Configure output directory (for local)
-- Recommendation to run `/sdp:export-issues <slug>` after configuration
-
 ## Output Format
 
 ### 1. Write Plan File
-Create `.sdp/specs/<slug>/plan.md` with all sections above in the configured language (`.sdp/config/language.yml`).
+Create `.sdp/specs/<slug>/plan.md` with sections 1-6 above in the configured language (`.sdp/config/language.yml`).
+
+**Note**: Do NOT include "Next Steps" section in the plan.md file. Next steps are only shown in the console output below.
 
 ### 2. Console Output
 Print a summary in the same language as the content:

--- a/.github/prompts/sdp-show-plan.prompt.md
+++ b/.github/prompts/sdp-show-plan.prompt.md
@@ -91,21 +91,13 @@ Based on confidence level and stddev:
 - **Resource buffer**: Key areas needing backup capacity
 - **Risk buffer**: Contingency for high-risk tasks
 
-### 7. Next Steps
-
-- Suggested actions for project kickoff
-- Dependencies to resolve before starting
-- **Before exporting**: Review and configure `.sdp/config/export.yml`:
-  - Set `destination` to `github` or `local`
-  - Configure repository (for GitHub)
-  - Configure output directory (for local)
-- Recommendation to run `/sdp-export-issues` after configuration
-
 ## Output Format
 
 ### 1. Write Plan File
 
-Create `.sdp/specs/${input:slug}/plan.md` with all sections above in the configured language (`.sdp/config/language.yml`).
+Create `.sdp/specs/${input:slug}/plan.md` with sections 1-6 above in the configured language (`.sdp/config/language.yml`).
+
+**Note**: Do NOT include "Next Steps" section in the plan.md file. Next steps are only shown in the console output below.
 
 ### 2. Console Output
 


### PR DESCRIPTION
This pull request updates the documentation and prompt templates for the SDP "show plan" feature to clarify the handling of the "Next Steps" section. The main change is to ensure that the "Next Steps" section is excluded from the generated `plan.md` file and is only displayed in the console output.

Documentation and prompt updates:

* Updated `.claude/commands/sdp/show-plan.md` to specify that the generated `.sdp/specs/<slug>/plan.md` file should only include sections 1-6, and explicitly note that the "Next Steps" section must not be included in the file but should appear in the console output.
* Updated `.github/prompts/sdp-show-plan.prompt.md` with matching instructions, clarifying that "Next Steps" is excluded from the plan file and only shown in the console output.