### PR TITLE
Feature/codex

### DIFF
--- a/.codex/prompts/README.md
+++ b/.codex/prompts/README.md
@@ -1,0 +1,61 @@
+# GitHub Copilot Prompt Files
+
+This directory contains prompt files for GitHub Copilot to support Spec-Driven Planning (SDP) workflow.
+
+## Setup
+
+To use these prompt files with GitHub Copilot:
+
+1. Initialize your project with the `--github-copilot` flag:
+   ```bash
+   npx spec-driven-planning init --github-copilot
+   ```
+
+2. Enable prompt files in VS Code:
+   - Open Settings (Cmd+, or Ctrl+,)
+   - Search for `chat.promptFiles`
+   - Enable the setting
+
+3. Reload VS Code to activate the prompt files
+
+## Available Commands
+
+| Command | Description |
+|---------|-------------|
+| `/sdp-steering` | Generate project context (product, tech, structure) |
+| `/sdp-requirement` | Refine and normalize requirements |
+| `/sdp-design` | Generate detailed design with alternatives |
+| `/sdp-estimate` | Generate task breakdown with PERT estimates |
+| `/sdp-show-plan` | Create visual project plan with Gantt chart |
+| `/sdp-export-issues` | Export tasks to GitHub Issues, Jira, Backlog, or local files |
+
+## Usage
+
+In the GitHub Copilot Chat view:
+
+1. Type `/` followed by the command name
+2. Add arguments as needed
+3. Press Enter to execute
+
+### Examples
+
+```
+/sdp-requirement Add user authentication feature
+/sdp-design add-user-authentication
+/sdp-estimate add-user-authentication
+/sdp-show-plan add-user-authentication
+/sdp-export-issues add-user-authentication
+```
+
+## Files
+
+- `sdp-requirement.prompt.md` - Requirement refinement prompt
+- `sdp-design.prompt.md` - Design generation prompt
+- `sdp-estimate.prompt.md` - Task estimation prompt
+- `sdp-show-plan.prompt.md` - Project plan generation prompt
+- `sdp-steering.prompt.md` - Project context generation prompt
+- `sdp-export-issues.prompt.md` - Issue export prompt
+
+## Documentation
+
+For more information, see the [main documentation](https://github.com/Basio0916/spec-driven-planning).

--- a/.codex/prompts/sdp-design-legacy.prompt.md
+++ b/.codex/prompts/sdp-design-legacy.prompt.md
@@ -1,0 +1,148 @@
+---
+description: Generate a detailed design document with decision rationale for a given requirement
+mode: agent
+---
+
+# SDP Design Generation
+
+Generate a detailed design document with decision rationale for a given requirement.
+
+## Input
+
+- **slug**: An existing requirement folder at `.sdp/specs/<slug>/` containing `requirement.md`
+- **Usage Example**: `/sdp-design add-user-authentication`
+
+## Language Configuration
+
+Read `.sdp/config/language.yml` to determine the output language:
+- If `language: en`, generate all content in **English**
+- If `language: ja`, generate all content in **Japanese**
+
+Use templates from `.sdp/templates/<lang>/` directory based on the configured language.
+
+## Context Files
+
+Read these for context:
+- `.sdp/specs/${input:slug}/requirement.md` - The requirement to design
+- `.sdp/tech.md` - Technical stack and constraints
+- `.sdp/structure.md` - Code structure and architecture
+- `.sdp/product.md` - Business context and goals
+
+## Pre-Check
+
+Before starting, verify that:
+- `.sdp/specs/${input:slug}/` directory exists
+- `.sdp/specs/${input:slug}/requirement.md` file exists
+
+Report errors if requirements are missing.
+
+## Design Process
+
+### 1. Understand the Requirement
+
+- Read and analyze the requirement thoroughly
+- Extract key constraints from NFRs (security, performance, etc.)
+- Identify technical boundaries from `.sdp/tech.md`
+
+### 2. Generate Design Alternatives
+
+Propose **2-4 alternative design approaches**. For each alternative:
+
+- **Overview**: High-level description (2-3 sentences)
+- **Architecture**: Component diagram, data flow, or module structure
+- **Pros**: Key advantages (3-5 bullet points)
+- **Cons**: Drawbacks and limitations (3-5 bullet points)
+- **Complexity**: Estimated implementation complexity (Low/Med/High)
+- **Risk**: Primary technical risks
+
+### 3. Comparative Analysis
+
+Create a comparison table covering:
+- Implementation effort
+- Maintainability
+- Performance characteristics
+- Scalability
+- Team familiarity
+- Technical debt implications
+
+### 4. Recommended Solution
+
+- **Selection rationale**: Why this design was chosen (1-2 paragraphs)
+- **Trade-offs**: What we're sacrificing and why it's acceptable
+- **Detailed design**: Architecture, data models, APIs, integration points
+- **Implementation notes**: Key technical decisions and guidelines
+
+## Deliverable
+
+Create `.sdp/specs/${input:slug}/design.md` following `.sdp/templates/<lang>/design.md` structure (use the language-specific template).
+
+**IMPORTANT - Response Length Management:**
+If the design document is expected to be very long and may exceed GitHub Copilot's response limit:
+1. First, create the file with sections 1-4 (Overview through Recommended Solution)
+2. Inform the user that detailed design sections will be added next
+3. Wait for user confirmation, then append sections 5-8 (Detailed Design through Open Questions)
+4. Use `replace_string_in_file` to append content, NOT rewrite the entire file
+
+## Design Document Structure
+
+The output must include:
+
+**Phase 1 (Core Design):**
+1. **Overview**: Summary of what's being designed
+2. **Design Alternatives**: 2-4 alternative approaches with pros/cons
+3. **Comparison Matrix**: Side-by-side comparison table
+4. **Recommended Solution**: Selected design with rationale
+
+**Phase 2 (Implementation Details):**
+5. **Detailed Design**: Architecture, data models, APIs, etc.
+6. **Trade-offs & Risks**: What we're accepting and why
+7. **Implementation Guidelines**: Technical decisions and conventions
+8. **Open Questions**: Unresolved items requiring user input (if any)
+
+## Output Format
+
+Generate all content based on the configured language (`.sdp/config/language.yml`).
+
+**For Phase 1 (Core Design) - After creating the initial file:**
+
+```
+【設計（フェーズ1）完了】
+📐 Slug: <slug>
+📝 タイトル: <設計タイトル>
+📁 ファイル: .sdp/specs/<slug>/design.md
+
+📊 検討した設計案: <数>
+✅ 採用案: <採用した設計名>
+📌 主要な判断理由: <1行要約>
+
+💡 次のステップ:
+  - 続けて詳細設計セクション（データモデル、API設計など）を追加する場合は「続けてください」と入力
+  - または設計内容を確認し、修正が必要な場合は自然言語で指示してください
+```
+
+**For Phase 2 (Implementation Details) - After completing all sections:**
+
+```
+【設計完了】
+📐 Slug: <slug>
+📝 タイトル: <設計タイトル>
+📁 ファイル: .sdp/specs/<slug>/design.md
+
+✅ すべてのセクションが完成しました
+
+💡 次のステップ:
+  - 設計内容を確認し、修正が必要な場合は自然言語で指示してください
+  - 設計が確定したら /sdp-estimate でタスク分解を実行してください
+```
+
+## User Iteration Support
+
+After generating the design:
+- User can provide natural language feedback
+- Update the design document based on feedback
+- Maintain version notes in the document
+- Re-evaluate alternatives if requested
+
+## Allowed Tools
+
+Read, Write, Edit, File Search, Grep only

--- a/.codex/prompts/sdp-design.prompt.md
+++ b/.codex/prompts/sdp-design.prompt.md
@@ -1,0 +1,237 @@
+---
+description: Generate comprehensive detailed design from selected pre-design option
+---
+
+# SDP: Design
+
+You are GitHub Copilot. Generate a comprehensive detailed design document based on a selected pre-design option.
+
+## Input
+- **slug**: The requirement slug (e.g., "add-user-authentication")
+- **alternative-number** (optional): Which alternative to detail (1, 2, 3, or 4). If not specified, use the recommended solution
+
+## Language Configuration
+
+Read `.sdp/config/language.yml` to determine the output language:
+- If `language: en`, generate all content in **English**
+- If `language: ja`, generate all content in **Japanese**
+
+Use templates from `.sdp/templates/<lang>/` directory based on the configured language.
+
+## Context Files
+Read these for context (in order of importance):
+1. `.sdp/specs/<slug>/pre-design.md` - The pre-design options (REQUIRED)
+2. `.sdp/specs/<slug>/requirement.md` - The requirement specification
+3. `.sdp/tech.md` - Technical stack and constraints
+4. `.sdp/structure.md` - Code structure and architecture
+5. `.sdp/product.md` - Business context and goals
+
+## Pre-Check
+
+Before starting, verify that:
+- `.sdp/specs/<slug>/` directory exists
+- `.sdp/specs/<slug>/requirement.md` file exists
+- `.sdp/specs/<slug>/pre-design.md` file exists
+
+Report errors if requirements are missing.
+
+## Alternative Selection Logic
+
+1. If `alternative-number` is provided (e.g., 1, 2, 3, 4):
+   - Read `pre-design.md` and extract the specified alternative
+   - Verify the alternative number exists
+   - Use that alternative as the basis for detailed design
+
+2. If `alternative-number` is NOT provided:
+   - Read `pre-design.md`
+   - Extract the "Recommended Solution" section
+   - Determine which alternative was recommended
+   - Use the recommended alternative as the basis for detailed design
+
+3. Output a clear statement at the beginning indicating which alternative is being detailed
+
+## Detailed Design Process
+
+### 1. Extract Base Design
+- Read the selected alternative from pre-design.md
+- Extract the overview, architecture, pros, cons as foundation
+- Keep the rationale and trade-offs from the recommendation
+
+### 2. Expand to Implementation-Ready Detail
+
+**IMPORTANT**: This document should be comprehensive enough for implementation. Include ALL necessary details.
+
+#### Architecture Details
+- **System Architecture**: Detailed component diagrams (use Mermaid when appropriate)
+- **Data Flow**: Detailed data flow diagrams showing all major paths
+- **Module Structure**: Detailed breakdown of modules/packages/services
+- **Integration Points**: How components interact with each other and external systems
+
+#### Data Model Details
+- **ER Diagrams**: Full entity-relationship diagrams (use Mermaid)
+- **Table Definitions**: Complete DDL with all columns, types, constraints, indexes
+- **Data Validation Rules**: Field-level validation requirements
+- **Migration Strategy**: How to migrate from current state (if applicable)
+
+#### API Specifications
+- **Endpoint Definitions**: Full REST/GraphQL/gRPC endpoint specifications
+- **Request/Response Schemas**: Complete schemas with examples
+- **Error Responses**: All error cases with codes and messages
+- **Authentication/Authorization**: Security requirements for each endpoint
+
+#### Security Design
+- **Authentication**: Detailed authentication mechanism
+- **Authorization**: Role-based or attribute-based access control details
+- **Data Protection**: Encryption at rest and in transit
+- **Security Headers**: Required HTTP headers
+- **Rate Limiting**: Specific rate limit rules
+- **Input Validation**: Validation and sanitization requirements
+
+#### Performance Design
+- **Performance Targets**: Specific latency/throughput requirements
+- **Caching Strategy**: What to cache, where, and for how long
+- **Database Optimization**: Indexes, query optimization, connection pooling
+- **Scalability Plan**: Horizontal/vertical scaling approach
+
+#### Error Handling
+- **Error Categories**: Define error types and codes
+- **Logging Strategy**: What to log, at what level, where
+- **Monitoring**: Key metrics to track
+- **Alerting**: When to alert and whom
+
+#### Implementation Guidelines
+- **File Structure**: Detailed file and directory organization
+- **Naming Conventions**: Specific naming rules for files, classes, functions
+- **Coding Standards**: Language-specific coding conventions
+- **Testing Strategy**: Unit, integration, e2e testing approach
+- **Implementation Order**: Step-by-step implementation sequence
+- **Dependencies**: New dependencies to add (with versions)
+
+### 3. Address Trade-offs and Risks
+- Expand on trade-offs mentioned in pre-design.md
+- Provide detailed mitigation strategies for identified risks
+- Add new risks discovered during detailed design
+- Create risk matrix with probability, impact, and mitigation
+
+### 4. Provide Implementation Guidance
+- Break down implementation into clear phases
+- Identify critical path items
+- Suggest rollback strategies
+- Provide testing checkpoints
+
+## Document Length Guidelines
+
+**Target length: 500-800 lines**
+
+Be comprehensive but focused:
+- ✅ Complete architecture diagrams
+- ✅ Full database schemas with DDL
+- ✅ Complete API specifications
+- ✅ Detailed security measures
+- ✅ Specific implementation steps
+- ✅ Concrete file structures
+- ❌ NO implementation code (unless small examples for clarity)
+- ❌ NO test code (describe test strategy instead)
+
+**The goal is to provide everything needed to implement, without actually implementing.**
+
+## Deliverable
+
+Create or update `.sdp/specs/<slug>/design.md` following `.sdp/templates/<lang>/design.md` structure (use the language-specific template).
+
+**Note**: The existing design.md template is comprehensive and suitable for detailed design. Use it as-is.
+
+## Detailed Design Document Structure
+
+The output must include (based on design.md template):
+
+1. **Title and Overview**: What's being designed (selected alternative)
+2. **Design Selection**: Which alternative was chosen and why (reference pre-design.md)
+3. **Architecture**: Detailed system architecture with diagrams
+4. **Component Design**: Detailed component breakdown
+5. **Data Models**: Complete ER diagrams and table definitions
+6. **API Design**: Full API specifications
+7. **Security Measures**: Comprehensive security design
+8. **Performance Optimization**: Caching, indexing, scaling strategies
+9. **Trade-offs & Risks**: Detailed risk analysis and mitigation
+10. **Implementation Guidelines**: File structure, conventions, implementation order
+11. **Testing Strategy**: Unit, integration, e2e testing approach
+12. **Open Questions**: Unresolved items (if any)
+
+## Output Format
+
+Generate all content based on the configured language (`.sdp/config/language.yml`).
+
+After writing the file, print a summary in the same language as the content:
+
+For Japanese:
+```
+【詳細設計完了】
+📐 Slug: <slug>
+📝 採用案: 設計案<N>: <設計名>
+📁 ファイル: .sdp/specs/<slug>/design.md
+
+📊 ドキュメントサイズ: <行数>行
+📌 主要コンポーネント: <数>個
+🗄️ テーブル数: <数>個
+🔌 API数: <数>個
+
+💡 次のステップ:
+  - 詳細設計を確認し、修正が必要な場合は自然言語で指示してください
+  - 設計が確定したら #sdp-estimate を使用してタスク分解を実行してください
+```
+
+For English:
+```
+【Detailed Design Completed】
+📐 Slug: <slug>
+📝 Selected: Alternative <N>: <design name>
+📁 File: .sdp/specs/<slug>/design.md
+
+📊 Document Size: <lines> lines
+📌 Main Components: <count>
+🗄️ Tables: <count>
+🔌 APIs: <count>
+
+💡 Next Steps:
+  - Review detailed design and provide feedback if changes needed
+  - When design is finalized: Use #sdp-estimate for task breakdown
+```
+
+## User Iteration Support
+
+After generating the detailed design:
+- User can provide natural language feedback
+- Update the design document based on feedback
+- Refine specific sections as requested
+- Add missing details if pointed out
+- Maintain version notes in the document
+
+## Design Quality Guidelines
+
+### Completeness
+- Include all information needed for implementation
+- Don't leave critical decisions to implementation phase
+- Specify exact technologies, libraries, versions when possible
+
+### Consistency with Context
+- **tech.md alignment**: Use stack and patterns from tech.md
+- **structure.md alignment**: Follow existing file organization patterns
+- **requirement.md alignment**: Satisfy all functional and non-functional requirements
+
+### Specificity
+- Use concrete values, not placeholders (e.g., "bcrypt cost factor: 12" not "appropriate cost factor")
+- Provide actual examples (e.g., actual JSON schemas, actual SQL DDL)
+- Give specific numbers (e.g., "100ms p99 latency" not "fast")
+
+### Implementability
+- Implementation order should be clear and logical
+- Dependencies should be explicitly stated
+- File structure should match structure.md conventions
+- No ambiguity about what needs to be built
+
+### Risk Awareness
+- Identify technical risks specific to the detailed design
+- Provide concrete mitigation strategies
+- Acknowledge uncertainties
+- Suggest monitoring and validation approaches

--- a/.codex/prompts/sdp-estimate.prompt.md
+++ b/.codex/prompts/sdp-estimate.prompt.md
@@ -1,0 +1,124 @@
+---
+description: Generate tasks and estimates grounded in this repository using PERT method
+mode: agent
+---
+
+# SDP Task Estimation
+
+Generate tasks and estimates for the given requirement using PERT method.
+
+## Inputs
+
+- **slug**: An existing requirement folder at `.sdp/specs/<slug>/`
+- **Usage Example**: `/sdp-estimate add-user-authentication`
+- **Estimation config**: `.sdp/config/estimate.yml` (T-shirt sizing, PERT constraints, buffers)
+- **Schema**: `.sdp/templates/<lang>/tasks.schema.yml` (Task structure definition)
+
+## Language Configuration
+
+Read `.sdp/config/language.yml` to determine the output language:
+- If `language: en`, generate all content in **English**
+- If `language: ja`, generate all content in **Japanese**
+
+## Context Files
+
+Read these for context:
+- `.sdp/specs/${input:slug}/requirement.md` - The requirement to decompose
+- `.sdp/specs/${input:slug}/design.md` - The design document (if exists)
+- `.sdp/tech.md` - Technical constraints affecting estimates
+- `.sdp/structure.md` - Existing modules and directories
+
+## Pre-Check
+
+Before starting, verify that:
+- `.sdp/specs/${input:slug}/` directory exists
+- `.sdp/specs/${input:slug}/requirement.md` file exists
+- `.sdp/specs/${input:slug}/design.md` file exists (optional, but recommended)
+
+Report errors if requirements are missing.
+
+## Task Decomposition Rules
+
+**Important**: If a design document exists (`.sdp/specs/${input:slug}/design.md`), use it as the primary source for task decomposition. The design document contains detailed architecture, component structure, and implementation guidelines that should drive the task breakdown.
+
+### Task Structure
+
+Decompose into **5–12 tasks** when possible. Each task must include:
+
+1. **Basic Info**:
+   - `id`: T-001, T-002, etc.
+   - `title`: Short, descriptive title
+   - `description`: 1–3 lines explaining the work
+
+2. **Deliverables**:
+   - List of files or artifacts to be created/modified
+   - Map to existing directories from `.sdp/structure.md`
+
+3. **Definition of Done (DoD)**:
+   - Bullet points with testable completion criteria
+
+4. **Dependencies**:
+   - `depends_on`: Array of task IDs that must complete first
+
+5. **Estimate** (PERT method):
+   - `method`: "pert"
+   - `optimistic`: Best-case hours
+   - `most_likely`: Most probable hours
+   - `pessimistic`: Worst-case hours
+   - `unit`: "h" (hours)
+
+6. **Risk Notes** (optional):
+   - Highlight technical risks or uncertainties
+
+### Critical Path Analysis
+
+- Identify the `critical_path`: Array of task IDs representing the longest dependency chain
+- This determines minimum project duration
+
+### Rollup Section
+
+Calculate project-level metrics:
+- `expected_hours`: Sum of PERT means ((optimistic + 4*most_likely + pessimistic) / 6)
+- `stddev_hours`: Propagated standard deviation (sqrt of sum of variances)
+- `confidence`: `low` | `med` | `high` with 1-line rationale
+- `rationale`: Brief explanation of confidence level
+
+### Estimation Guidelines
+
+Reference `.sdp/config/estimate.yml`:
+- Use T-shirt sizing as reference (S=3h, M=6h, L=12h, XL=24h)
+- Apply PERT constraints (min=1h, max=40h per task)
+- Consider 15% schedule buffer for rollup
+
+## Output Format
+
+### 1. Write YAML File
+
+Create `.sdp/specs/${input:slug}/tasks.yml` following the schema exactly.
+
+### 2. Console Output
+
+Print a summary in the configured language (`.sdp/config/language.yml`):
+
+```
+【タスク分解完了】
+📋 要件: <slug>
+📊 タスク数: <数>
+⏱️  予想時間: <expected_hours>h (標準偏差: <stddev_hours>h)
+🎯 信頼度: <confidence>
+
+タスク一覧:
+| ID    | タイトル              | 見積時間 |
+|-------|----------------------|----------|
+| T-001 | <title>              | <mean>h  |
+| T-002 | <title>              | <mean>h  |
+...
+
+🔗 クリティカルパス: T-001 → T-003 → T-007
+
+💡 次のステップ: /sdp-show-plan でプロジェクト計画を生成してください
+```
+
+## Allowed Tools
+
+Read, Write, Edit, File Search, Grep only

--- a/.codex/prompts/sdp-export-issues.prompt.md
+++ b/.codex/prompts/sdp-export-issues.prompt.md
@@ -1,0 +1,162 @@
+---
+description: Export task breakdown to GitHub Issues, Jira Issues, or local markdown files
+mode: agent
+---
+
+# SDP Export Issues
+
+Export task breakdown to GitHub Issues, Jira Issues, or local markdown files.
+
+## Inputs
+
+- **slug**: An existing requirement folder at `.sdp/specs/<slug>/` containing `tasks.yml`
+- **Usage Example**: `/sdp-export-issues add-user-authentication`
+- **Export Config**: `.sdp/config/export.yml` (output destination, repository, labels)
+
+## Language Configuration
+
+Read `.sdp/config/language.yml` to determine the output language:
+- If `language: en`, generate all content in **English**
+- If `language: ja`, generate all content in **Japanese**
+
+Console output should also be in the configured language.
+
+## Context Files
+
+Read these for context:
+- `.sdp/specs/${input:slug}/tasks.yml` - Task breakdown to export
+- `.sdp/specs/${input:slug}/requirement.md` - Original requirement
+- `.sdp/config/export.yml` - Export configuration (destination, repo, labels)
+
+## Pre-Check
+
+Before starting, verify that:
+- `.sdp/specs/${input:slug}/` directory exists
+- `.sdp/specs/${input:slug}/tasks.yml` file exists
+- `.sdp/config/export.yml` file exists
+
+Report errors if files are missing.
+
+## Important: Configure Before Running
+
+**Before running this command, you MUST configure `.sdp/config/export.yml`**:
+
+1. **Set export destination**: Choose `destination: github` or `destination: local`
+2. **Configure GitHub settings** (if using GitHub mode):
+   - Set `github.repo` to your repository (e.g., "owner/repo")
+   - Customize `github.labels` as needed
+3. **Configure local settings** (if using local mode):
+   - Set `local.out_dir` if different from default
+
+**User should review and edit `.sdp/config/export.yml` before proceeding.**
+
+## Step 1: Load Export Configuration
+
+Read `.sdp/config/export.yml` to determine:
+- `destination`: Export target (`github`, `jira`, or `local`)
+- Destination-specific settings (repository, project, labels, etc.)
+- `issue_mode`: How to organize tasks
+  - `sub_issues` / `sub_tasks`: Create parent-child relationships
+  - `linked_issues`: Create separate issues with links
+  - `single_issue`: Create one comprehensive issue with all tasks
+
+## Step 2: Determine Export Destination
+
+Based on the `destination` field in export.yml:
+- **`github`**: Export to GitHub Issues (requires `gh` CLI)
+- **`jira`**: Export to Jira Issues (uses REST API v3)
+- **`backlog`**: Export to Backlog Issues (uses REST API v2)
+- **`local`**: Export to local markdown files (no external tools required)
+
+### Implementation Details
+
+For detailed implementation instructions, refer to:
+- **GitHub mode**: `.sdp/docs/export-github.md`
+- **Jira mode**: `.sdp/docs/export-jira.md`
+- **Backlog mode**: `.sdp/docs/export-backlog.md`
+- **Local mode**: `.sdp/docs/export-local.md`
+
+## Step 3: Execute Export
+
+### GitHub Export
+
+If `destination: github`, read `.sdp/docs/export-github.md` for complete implementation details.
+
+**Summary**:
+1. Check `gh` CLI availability and authentication
+2. Check `gh sub-issue` extension if needed
+3. Create main issue using appropriate template
+4. Create task issues if using sub_issues or linked_issues mode
+5. Generate console output with issue URLs
+
+### Jira Export
+
+If `destination: jira`, read `.sdp/docs/export-jira.md` for complete implementation details.
+
+**Summary**:
+1. Check Jira configuration (url, email, project, API token)
+2. Load templates and convert Wiki Markup to ADF
+3. Create main issue via REST API
+4. Create task issues if using sub_tasks or linked_issues mode
+5. Generate console output with issue URLs
+
+### Backlog Export
+
+If `destination: backlog`, read `.sdp/docs/export-backlog.md` for complete implementation details.
+
+**Summary**:
+1. Check Backlog configuration (space_key, project_key, API key)
+2. Get project ID and issue type IDs via REST API
+3. Create main issue with Markdown description
+4. Create task issues if using sub_tasks or linked_issues mode
+5. Generate console output with issue URLs
+
+### Local Export
+
+If `destination: local`, read `.sdp/docs/export-local.md` for complete implementation details.
+
+**Summary**:
+1. Create output directory if needed
+2. Generate markdown file with issue drafts
+3. Generate console output with file path
+
+## Issue Templates
+
+### Issue Title Format
+- Main issue: `[<slug>] <requirement title>`
+- Task issue: `[<slug>][T-xxx] <task.title>`
+
+### Issue Body Templates
+
+Use templates from `.sdp/templates/<lang>/`:
+- `issue-single.md` - For single issue mode
+- `issue-main.md` - For main requirement issue
+- `issue-task.md` - For individual task issues
+
+Replace placeholders with actual values from requirement and tasks files.
+
+## Console Output Format
+
+After export completes, print a summary:
+
+```
+【エクスポート完了】
+📋 要件: <slug>
+🎯 エクスポート先: <destination>
+📊 作成されたIssue数: <count>
+
+Issue URL:
+- メインIssue: <main_issue_url>
+- タスクIssue:
+  - T-001: <task_issue_url>
+  - T-002: <task_issue_url>
+  ...
+
+💡 次のステップ:
+  - Issueボードで進捗を管理してください
+  - 必要に応じてタスクの優先順位を調整してください
+```
+
+## Allowed Tools
+
+Read, Write, Terminal, File Search, Grep

--- a/.codex/prompts/sdp-implement.prompt.md
+++ b/.codex/prompts/sdp-implement.prompt.md
@@ -1,0 +1,89 @@
+---
+description: Execute implementation tasks based on SDP design and task specifications
+mode: agent
+---
+
+# SDP Implementation Executor
+
+Implement repository changes for the specified requirement by executing the approved task plan.
+
+## Command Usage
+`sdp-implement <slug> [task-id ...]`
+- `<slug>` corresponds to `.sdp/specs/<slug>/`
+- Optional `task-id` arguments (e.g., `T-002`) restrict execution to those tasks
+- When no task IDs are supplied, execute **all** tasks defined in `tasks.yml`
+
+## Language Configuration
+Read `.sdp/config/language.yml`:
+- `language: en` → produce summaries in **English**
+- `language: ja` → produce summaries in **Japanese**
+
+Use templates from `.sdp/templates/<lang>/` to structure artifacts.
+
+## Required Context Files
+Read before starting:
+- `.sdp/specs/<slug>/requirement.md`
+- `.sdp/specs/<slug>/design.md`
+- `.sdp/specs/<slug>/tasks.yml`
+- `.sdp/product.md`
+- `.sdp/tech.md`
+- `.sdp/structure.md`
+- `.sdp/specs/<slug>/implementation.md` (if present)
+
+## Pre-Flight Checks
+1. Ensure `.sdp/specs/<slug>/` exists.
+2. Ensure `requirement.md` and `tasks.yml` exist; warn (but continue) if `design.md` is missing.
+3. Validate provided task IDs; abort if any are unknown.
+4. Confirm working tree status and surface existing uncommitted changes.
+5. Respect task dependencies declared in `tasks.yml`; notify if the requested subset violates ordering.
+
+## Implementation Loop
+For each selected task:
+1. **Intent Alignment**
+   - Summarize task objective referencing design, steering docs, and task metadata.
+2. **Plan**
+   - Outline required code edits, new files, migrations, docs, and tests.
+3. **Execute**
+   - Modify repository files using native tools only.
+   - Follow project conventions (style, naming, folder placement).
+   - Update or add tests that satisfy the Definition of Done.
+4. **Verify**
+   - Run appropriate tests or commands tied to the task’s DoD.
+   - Record failures, retries, and resolutions (or residual issues).
+5. **Document**
+   - Update `.sdp/specs/<slug>/implementation.md` using `.sdp/templates/<lang>/implementation.md`.
+   - Append a new section per task run, capturing:
+     - Date/time, task ID & title
+     - Code change summary and rationale
+     - Files touched (with purpose)
+     - DoD verification steps
+     - Test commands and outcomes
+     - New risks or follow-up actions
+
+## Implementation Log Handling
+- **CREATE mode**: When `implementation.md` is absent, instantiate it from the template.
+- **UPDATE mode**: Append a new iteration section while preserving existing history.
+- Maintain chronological ordering and clearly separated task entries.
+
+## Completion Summary
+Output a localized summary:
+```
+【実装完了】 / 【Implementation Complete】
+📐 Requirement: <slug>
+🛠️ Tasks executed: <T-IDs>
+📁 Files changed: <count>
+✅ Test status: <pass/fail with notes>
+⚠️ Follow-ups: <list or "None">
+
+💡 Next steps:
+  - Suggest review or subsequent commands (e.g., /sdp-show-plan <slug>)
+```
+
+## Principles
+- Minimize scope creep—deliver only what the task requires.
+- Surface assumptions and blockers transparently in the log.
+- Never leave the repository broken; if unavoidable, document rollback steps.
+- Do not use shell commands outside the supported toolset.
+
+## Allowed Tools
+Read, Write, Edit, File Search, Grep

--- a/.codex/prompts/sdp-pre-design.prompt.md
+++ b/.codex/prompts/sdp-pre-design.prompt.md
@@ -1,0 +1,234 @@
+---
+description: Generate lightweight pre-design document (2-4 design options) for requirement
+---
+
+# SDP: Pre-Design
+
+You are GitHub Copilot. Generate a lightweight pre-design document that compares 2-4 design approaches for a given requirement.
+
+## Input
+- **slug**: Provide the requirement slug (e.g., "add-user-authentication")
+
+## Language Configuration
+
+Read `.sdp/config/language.yml` to determine the output language:
+- If `language: en`, generate all content in **English**
+- If `language: ja`, generate all content in **Japanese**
+
+Use templates from `.sdp/templates/<lang>/` directory based on the configured language.
+
+## Context Files
+Read these for context:
+- `.sdp/specs/<slug>/requirement.md` - The requirement to design
+- `.sdp/tech.md` - Technical stack and constraints
+- `.sdp/structure.md` - Code structure and architecture
+- `.sdp/product.md` - Business context and goals
+
+## Pre-Check
+
+Before starting, verify that:
+- `.sdp/specs/<slug>/` directory exists
+- `.sdp/specs/<slug>/requirement.md` file exists
+
+Report errors if requirements are missing.
+
+## Pre-Design Process
+
+### 1. Understand the Requirement & Architecture Context
+- Read and analyze the requirement thoroughly
+- Extract key constraints from NFRs (security, performance, etc.)
+- Identify technical boundaries from `.sdp/tech.md`
+- Inspect `.sdp/structure.md` and relevant source directories to infer the prevailing architecture style (Clean, Hexagonal, Layered, Microservices, Event-Driven, Serverless, etc.)
+- Capture explicit architecture signals:
+  - **Clean / Onion / Hexagonal**: `domain/`, `usecase/`, `application/`, `adapter/`, `interface/`
+  - **Layered (MVC, MVVM, etc.)**: `controllers/`, `views/`, `services/`
+  - **Microservices / Modular Monolith**: multiple service modules, independent deployment manifests
+  - **Event-Driven / CQRS**: `events/`, `subscribers/`, `queues/`, separate read/write models
+  - **Serverless**: function directories, infrastructure-as-code for FaaS
+- Record architecture guardrails that must be respected (e.g., "domain layer must remain framework-agnostic")
+
+### 2. Generate 2-4 Design Options
+
+**IMPORTANT**: Keep this lightweight and focused on comparison. **DO NOT** include detailed specifications in this document. Save detailed design for the next step.
+
+For each alternative (2-4 alternatives):
+
+**Overview** (2-3 sentences)
+- High-level description of the approach
+- Key distinguishing characteristics
+
+**Architecture** (Simple text diagram or brief description)
+- Show key components and data flow
+- Keep it simple - use ASCII diagrams or brief bullet points
+- **NO** detailed class diagrams, **NO** detailed sequence diagrams
+
+**Architecture Alignment & Best Practices**
+- Explain how the approach respects the inferred architecture style and layering
+- Call out where dependency inversion or abstractions are required
+- Highlight deviations and mitigation or migration plans
+
+**Domain Logic Placement**
+- Describe where core business rules reside
+- Ensure domain/use case layers remain decoupled from infrastructure concerns
+- Note impacts on aggregates, bounded contexts, or module ownership
+
+**Pros** (3-5 bullet points)
+- Key advantages (tie to NFRs, architecture goals, business KPIs when possible)
+
+**Cons** (3-5 bullet points)
+- Drawbacks and limitations; be honest about trade-offs
+
+**Implementation Complexity**: Low / Med / High
+- Include a brief justification (1 sentence) and mention migration effort if refactoring is needed
+
+**Primary Risks** (1-2 sentences)
+- Main technical or architecture integrity risks for this approach
+
+### 3. Comparative Analysis
+
+Create a comparison table with criteria such as:
+- Implementation effort (person-days estimate)
+- Architecture fit / cleanliness (High/Med/Low)
+- Domain integrity impact (Strong/Neutral/Weak)
+- Maintainability (High/Med/Low)
+- Performance characteristics (concrete metrics when possible)
+- Scalability (High/Med/Low)
+- Team familiarity (High/Med/Low)
+- Technical debt implications (Low/Med/High)
+- Security (High/Med/Low)
+- Cost (Low/Med/High)
+- Operational complexity / deployment impact (Low/Med/High)
+
+**Adjust criteria based on the specific requirement and project context.**
+
+### 4. Recommended Solution
+
+**Selection rationale** (3-5 sentences)
+- Why this design was chosen over alternatives
+- How it preserves or intentionally evolves the current architecture style
+- What key factors (NFRs, business goals, domain boundaries) drove the decision
+- Reference to product.md business goals when applicable
+
+**Key Trade-offs** (2-4 bullet points)
+- What we're sacrificing and why it's acceptable
+- Be explicit about what we're NOT optimizing for
+- Call out any architecture guardrail exceptions and planned mitigation
+
+## Document Length Guidelines
+
+**Target length: 200-400 lines**
+
+Keep it concise:
+- ✅ Focus on comparison and decision-making
+- ✅ Simple architecture diagrams (ASCII/text)
+- ✅ Brief pros/cons lists
+- ❌ NO detailed API specifications
+- ❌ NO detailed database schemas
+- ❌ NO detailed implementation code
+- ❌ NO detailed security measures
+- ❌ NO detailed file structures
+
+**The goal is to help the user choose a direction, not to provide implementation details.**
+
+## Deliverable
+
+Create `.sdp/specs/<slug>/pre-design.md` following `.sdp/templates/<lang>/pre-design.md` structure (use the language-specific template).
+
+## Pre-Design Document Structure
+
+The output must include:
+
+1. **Overview**: Summary of what's being designed (2-3 sentences)
+2. **Alternative 1**: First design approach
+3. **Alternative 2**: Second design approach
+4. **Alternative 3**: Third design approach (optional but recommended)
+5. **Alternative 4**: Fourth design approach (optional)
+6. **Comparison Matrix**: Side-by-side comparison table
+7. **Recommended Solution**: Selected design with rationale and trade-offs
+8. **Next Steps**: Instructions for proceeding to detailed design
+
+## Output Format
+
+Generate all content based on the configured language (`.sdp/config/language.yml`).
+
+After writing the file, print a summary in the same language as the content:
+
+For Japanese:
+```
+【設計案作成完了】
+📐 Slug: <slug>
+📝 タイトル: <設計タイトル>
+📁 ファイル: .sdp/specs/<slug>/pre-design.md
+
+📊 評価した設計案: <数>件
+✅ 推奨案: <推奨する設計名>
+📌 主要な選定理由: <1行要約>
+
+💡 次のステップ:
+  - 設計案を確認し、修正が必要な場合は自然言語で指示してください
+  - 推奨案で進める場合: /sdp:design <slug>
+  - 別の設計案を選ぶ場合: /sdp:design <slug> <設計案番号>
+```
+
+For English:
+```
+【Pre-Design Completed】
+📐 Slug: <slug>
+📝 Title: <design title>
+📁 File: .sdp/specs/<slug>/pre-design.md
+
+📊 Alternatives Evaluated: <number>
+✅ Recommended: <recommended design name>
+📌 Key Rationale: <one-line summary>
+
+💡 Next Steps:
+  - Review alternatives and provide feedback if changes needed
+  - To proceed with recommended: /sdp:design <slug>
+  - To select different alternative: /sdp:design <slug> <alternative-number>
+```
+
+## User Iteration Support
+
+After generating the pre-design:
+- User can provide natural language feedback
+- Update the alternatives document based on feedback
+- Add new alternatives if requested
+- Refine comparison matrix if needed
+- Re-evaluate recommendation if requested
+
+## Design Quality Guidelines
+
+### Ensure Alternatives are Truly Different
+- Each alternative should represent a fundamentally different approach
+- Avoid alternatives that are just minor variations
+- Consider different: architectures, technologies, paradigms, complexity levels
+
+### Make Comparisons Objective
+- Use concrete metrics when possible (e.g., "100ms response time" vs "fast")
+- Provide evidence from tech.md or product.md
+- Acknowledge uncertainty when estimating
+
+### Align with Project Context
+- Reference constraints from tech.md (stack, infrastructure, skills)
+- Reference goals from product.md (KPIs, user needs)
+- Reference existing patterns from structure.md
+- Consider team's current skill level and learning curve
+
+### Architecture-Aware Heuristics
+- **Clean / Onion / Hexagonal**: Keep domain entities and use cases free from framework dependencies; push IO/persistence to adapters; favor dependency inversion with interfaces in domain/application layers
+- **Layered (MVC, MVVM, 3-tier)**: Maintain thin controllers; keep business rules in service/domain layers; manage DTO ↔ domain conversions and transaction boundaries consciously
+- **Microservices / Modular Monolith**: Define bounded contexts, data ownership, and integration modes (sync vs async); plan observability, auth, and versioning consistently per service
+- **Event-Driven / CQRS**: Separate write/read models only when justified; articulate event contracts, delivery guarantees, and failure handling; keep domain events aligned with ubiquitous language without leaking infrastructure concerns
+- **Serverless / FaaS**: Clarify function boundaries, statelessness, and cold-start mitigation; design shared service layers that prevent logic duplication; emphasize observability, idempotency, and retry strategies
+
+### Be Honest About Trade-offs
+- Every design has trade-offs - make them explicit
+- Don't oversell the recommended solution
+- Acknowledge what you're NOT optimizing for
+
+## Cross-Platform Compatibility
+
+This prompt works on all platforms (Windows, macOS, Linux) because it relies on GitHub Copilot's native file operations rather than shell-specific commands.
+
+## Allowed Tools
+Read, Write, Edit, File Search, Grep only

--- a/.codex/prompts/sdp-requirement.prompt.md
+++ b/.codex/prompts/sdp-requirement.prompt.md
@@ -1,0 +1,102 @@
+---
+description: Refine a requirement and normalize it for task generation
+mode: agent
+---
+
+# SDP Requirement Refinement
+
+Refine a requirement and normalize it for task generation.
+
+## Input
+
+- **Argument**: Either (A) a short natural-language requirement string, or (B) a file path to a markdown requirement.
+- If a path is given, read it. Otherwise, take the argument string as the base requirement.
+- **Usage Example**: `/sdp-requirement Add user authentication`
+
+## Language Configuration
+
+Read `.sdp/config/language.yml` to determine the output language:
+- If `language: en`, generate all content in **English**
+- If `language: ja`, generate all content in **Japanese**
+
+Use templates from `.sdp/templates/<lang>/` directory based on the configured language.
+
+## Context Files
+
+Read these for context:
+- `.sdp/product.md` - Business context and goals
+- `.sdp/tech.md` - Technical stack and constraints
+- `.sdp/structure.md` - Code structure and organization
+
+## Slug Generation
+
+- Generate a slug from the requirement text:
+  - Convert to lowercase
+  - Replace spaces and special characters with hyphens
+  - Remove consecutive hyphens
+  - Limit to 50 characters
+  - Examples: "Add user authentication" → "add-user-authentication", "RESTful API for products" → "restful-api-for-products"
+- Check for duplicate slugs in `.sdp/specs/` directory by listing existing folders
+- If duplicate exists, append `-2`, `-3`, etc.
+- Create `.sdp/specs/` directory if it doesn't exist
+
+## Deliverable
+
+- Create or update a file at `.sdp/specs/<slug>/requirement.md` with the refined spec.
+- Create the `.sdp/specs/<slug>/` directory if it doesn't exist
+- The file must follow `.sdp/templates/<lang>/requirement.md` sections exactly (use the language-specific template).
+
+## Refinement Rules
+
+### Content Alignment
+
+- **Product alignment**: Align with `.sdp/product.md` (goals/KPIs)
+- **Technical feasibility**: Consider constraints from `.sdp/tech.md`
+- **Structure awareness**: Reference existing modules from `.sdp/structure.md`
+
+### Required Sections (from template)
+
+1. **機能概要** (Feature Overview): Business goal and feature purpose statement
+2. **ユーザーストーリー** (User Stories): User stories in "Who/What/Why" format
+3. **機能要件** (Functional Requirements): Functional requirements with detailed descriptions and acceptance criteria (checklist format)
+4. **非機能要件** (Non-Functional Requirements): Non-functional requirements (performance, security, maintainability, etc.) as needed
+
+### Scoping Guidelines
+
+- **MVP focus**: Constrain scope to MVP if ambiguous
+- **Clear boundaries**: Explicitly state what's in/out of scope
+- **Incremental delivery**: Break large features into smaller requirements if needed
+
+## Output Format
+
+Generate all content based on the configured language (`.sdp/config/language.yml`).
+
+After writing the file, print a summary in the same language as the content:
+
+For Japanese:
+```
+【要件定義完了】
+📋 Slug: <slug>
+📝 タイトル: <要件タイトル>
+📁 ファイル: .sdp/specs/<slug>/requirement.md
+
+💡 次のステップ:
+  - 要件内容を確認し、修正が必要な場合は自然言語で指示してください
+  - 要件が確定したら #sdp-pre-design で設計案を評価してください
+```
+
+For English:
+```
+【Requirement Definition Completed】
+📋 Slug: <slug>
+📝 Title: <requirement title>
+📁 File: .sdp/specs/<slug>/requirement.md
+
+💡 Next Steps:
+  - Review the requirement and provide feedback if changes needed
+  - When requirement is finalized: Use #sdp-pre-design to evaluate design options
+```
+
+## Allowed Tools
+
+Read, Write, Edit, File Search, Grep only

--- a/.codex/prompts/sdp-show-plan.prompt.md
+++ b/.codex/prompts/sdp-show-plan.prompt.md
@@ -1,0 +1,129 @@
+---
+description: Transform a task breakdown into a human-readable project plan
+mode: agent
+---
+
+# SDP Project Plan Generation
+
+Transform a task breakdown into a human-readable project plan.
+
+## Input
+
+- **slug**: An existing requirement folder at `.sdp/specs/<slug>/` containing `tasks.yml`
+- **Usage Example**: `/sdp-show-plan add-user-authentication`
+
+## Language Configuration
+
+Read `.sdp/config/language.yml` to determine the output language:
+- If `language: en`, generate all content in **English**
+- If `language: ja`, generate all content in **Japanese**
+
+## Context Files
+
+Read these for context:
+- `.sdp/specs/${input:slug}/tasks.yml` - Task breakdown and estimates
+- `.sdp/specs/${input:slug}/requirement.md` - Original requirement
+- `.sdp/product.md` - Business context
+
+## Pre-Check
+
+Before starting, verify that:
+- `.sdp/specs/${input:slug}/` directory exists
+- `.sdp/specs/${input:slug}/tasks.yml` file exists
+
+Report errors if files are missing.
+
+## Plan Structure
+
+Generate a comprehensive project plan document with the following sections:
+
+### 1. Overview
+
+- **Purpose**: 1 paragraph summarizing the requirement and approach
+- **Scope**: Key deliverables and boundaries
+- **Timeline Summary**: Total estimated hours, confidence level
+
+### 2. Task Breakdown
+
+- **Table format** with columns:
+  - Task ID
+  - Title
+  - Estimate (hours)
+  - Dependencies
+
+### 3. Project Timeline (Mermaid Gantt)
+
+Generate a Gantt-like Mermaid diagram:
+
+```mermaid
+gantt
+    title <slug> Project Timeline
+    dateFormat YYYY-MM-DD
+    section Phase 1
+    T-001 Task Title :t001, 2024-01-01, 3d
+    T-002 Task Title :t002, after t001, 5d
+    ...
+```
+
+Use task IDs and dependencies to show:
+- Sequential vs. parallel work
+- Critical path highlighted
+- Milestone markers
+
+### 4. Risk Register
+
+List **top 3 risks** from task breakdown:
+- **Risk description**
+- **Probability**: Low/Medium/High
+- **Impact**: Low/Medium/High
+- **Mitigation strategy**
+
+### 5. Critical Path Analysis
+
+- **Critical path**: List of task IDs (e.g., T-001 → T-003 → T-007)
+- **Duration**: Total hours on critical path
+- **Bottlenecks**: Tasks with most dependencies or highest risk
+
+### 6. Buffer Recommendation
+
+Based on confidence level and stddev:
+- **Schedule buffer**: Recommended % or hours
+- **Resource buffer**: Key areas needing backup capacity
+- **Risk buffer**: Contingency for high-risk tasks
+
+## Output Format
+
+### 1. Write Plan File
+
+Create `.sdp/specs/${input:slug}/plan.md` with sections 1-6 above in the configured language (`.sdp/config/language.yml`).
+
+**Note**: Do NOT include "Next Steps" section in the plan.md file. Next steps are only shown in the console output below.
+
+### 2. Console Output
+
+Print a summary in the same language as the content:
+
+```
+【プロジェクト計画生成完了】
+📋 要件: <slug>
+📁 ファイル: .sdp/specs/<slug>/plan.md
+
+📊 概要:
+- タスク数: <数>
+- 予想時間: <expected_hours>h
+- クリティカルパス: <critical_path_duration>h
+- 推奨バッファ: <buffer>%
+
+⚠️  主要リスク: <top_risk_summary>
+
+💡 次のステップ:
+   1. .sdp/config/export.yml を確認・編集してください
+      - destination: github または local を選択
+      - GitHub使用時: repo を設定
+      - ローカル使用時: out_dir を設定
+   2. /sdp-export-issues でタスクをエクスポートしてください
+```
+
+## Allowed Tools
+
+Read, Write, Edit, File Search, Grep only

--- a/.codex/prompts/sdp-steering.prompt.md
+++ b/.codex/prompts/sdp-steering.prompt.md
@@ -1,0 +1,163 @@
+---
+description: Perform an intelligent project steering pass to create or update project context documents
+mode: agent
+---
+
+# SDP Project Steering
+
+Perform an intelligent "project steering" pass that creates or updates steering documents based on project state.
+
+## Pre-Analysis: Detect Existing Files
+
+Before starting, check which steering documents already exist by reading the filesystem:
+- Check if `.sdp/product.md`, `.sdp/tech.md`, and `.sdp/structure.md` exist
+- Determine CREATE mode (if file doesn't exist) or UPDATE mode (if file exists)
+- Create the `.sdp/` directory if it doesn't exist
+- Check recent git commits if this is an update (optional)
+
+## Language Configuration
+
+Read `.sdp/config/language.yml` to determine the output language:
+- If `language: en`, generate all content in **English**
+- If `language: ja`, generate all content in **Japanese**
+
+Use templates from `.sdp/templates/<lang>/` directory based on the configured language.
+
+## Goals
+
+Create or update three steering documents in `.sdp/` directory:
+- **product.md**: Business goals, user stories, KPIs
+- **tech.md**: Stack, services, contracts, constraints, risks
+- **structure.md**: Folders, modules, entry points, data flows
+
+## Smart Update Strategy
+
+### For NEW files (CREATE mode):
+Generate comprehensive initial content covering all aspects of the project.
+
+### For EXISTING files (UPDATE mode):
+1. **Always Read existing file first** - Understand current content
+2. **Preserve user customizations** - Maintain manual edits and custom sections
+3. **Update factual information only** - Dependencies, file structures, commands
+4. **Add new sections only when significant** - Only for major feature additions
+5. **Mark deprecation instead of deletion** - Use ~~strikethrough~~ or [DEPRECATED] tags
+6. **Maintain existing format** - Respect markdown style choices
+
+## Repository Scanning Steps
+
+### 1. Project Analysis
+
+Use available tools (file search, grep, read file) to scan the codebase and extract information from:
+- **Product signals**: README, docs/, package.json, go.mod, etc.
+- **Tech/infra**: Dockerfile, docker-compose, Terraform, CI files, Makefile, schema (OpenAPI/GraphQL)
+- **Structure**: Directories, domains, entrypoints, major modules
+
+### 2. Generate/Update Each File
+
+Use templates at `.sdp/templates/<lang>/*.md` as the structural guide (based on configured language). Keep sections even if empty.
+
+#### product.md Content (if CREATE mode):
+- **Vision**: Product's raison d'être (1-2 sentences)
+- **Target Users / JTBD**: User types and problems to solve
+- **Core Value / KPIs**: Key metrics and targets (table format)
+- **Top User Stories (MVP)**: High-priority user stories
+- **Out of Scope (MVP)**: Explicitly out-of-scope items
+- **Business Constraints**: License, cost, deadline constraints
+
+#### product.md Updates (if UPDATE mode):
+Update only if these changes occurred:
+- New features added
+- Deprecated/removed features
+- Changed use cases or target users
+- Updated value propositions
+
+#### tech.md Content (if CREATE mode):
+- **Stack & Services**:
+  - Backend: Language/Framework
+  - Frontend: Framework/Libraries
+  - DB: Database type/service
+  - Infra: Cloud/CI/CD environment
+- **Interfaces/Contracts**: GraphQL/OpenAPI schema, Events/Queues
+- **Observability & Quality**:
+  - Logging/Tracing/Metrics
+  - Testing strategy (unit/integration/e2e)
+  - Security baseline
+- **Constraints & Risks**: Major technical constraints and risks
+
+#### tech.md Updates (if UPDATE mode):
+Check for these changes:
+- New dependencies added
+- Removed libraries/frameworks
+- Major version upgrades
+- New development tools or build processes
+- Changed environment variables or configuration
+- Modified port assignments or service architecture
+
+#### structure.md Content (if CREATE mode):
+- **High-level**:
+  - Entrypoints: Application entry points
+  - Modules / Packages: Major modules/packages
+  - Data flow: Data flow and processing patterns
+- **Directory Map**: Directory structure and role of each directory
+
+#### structure.md Updates (if UPDATE mode):
+Check for these changes:
+- New directories or major reorganization
+- Changed file organization patterns
+- New or modified naming conventions
+- Updated architectural patterns or principles
+- Refactored code structure or module boundaries
+
+### 3. Write Files
+
+- **Location**: `.sdp/` directory (.sdp/product.md, .sdp/tech.md, .sdp/structure.md)
+- **Overwrite**: In UPDATE mode, respect existing content but allow overwrite
+- **Template compliance**: Follow `.sdp/templates/*.md` structure
+
+### 4. Console Summary
+
+Generate a concise summary in **Japanese**:
+
+```
+【Steering更新完了】
+✅ product.md: [作成/更新] - <変更概要>
+✅ tech.md: [作成/更新] - <変更概要>
+✅ structure.md: [作成/更新] - <変更概要>
+
+📚 参照ファイル: <使用したファイルパスのリスト>
+
+💡 次のステップ: /sdp-requirement コマンドで要件定義を開始してください
+```
+
+## Important Principles
+
+### Security Guidelines
+- **No sensitive data**: Never include API keys, passwords, database credentials, or personal information
+- **Review before commit**: Always review content before version control
+- **Team sharing consideration**: Steering files are shared with all project collaborators
+
+### Content Quality Guidelines
+- **Single domain focus**: Each file should cover one specific area
+- **Clear and specific**: Provide concrete examples and rationale, not abstract principles
+- **Regular maintenance**: Review after major project changes
+- **Actionable guidance**: Write specific, implementable guidelines
+
+### Preservation Strategy (UPDATE mode)
+- **User sections**: Preserve sections not in standard template
+- **Custom examples**: Maintain user-added examples
+- **Comments**: Keep inline comments and notes
+- **Formatting preferences**: Respect existing markdown style choices
+
+### Update Philosophy (UPDATE mode)
+- **Additive by default**: Add rather than replace
+- **Mark deprecation**: Use ~~strikethrough~~ or [DEPRECATED] tags
+- **Date significant changes**: Add update timestamps for major changes
+- **Explain changes**: Brief notes on why something was updated
+
+## Output Language
+
+Generate all console output in the configured language (`.sdp/config/language.yml`).
+
+## Allowed Tools
+
+Read, Write, Edit, File Search, Grep only

--- a/README.ja.md
+++ b/README.ja.md
@@ -23,6 +23,12 @@ npx spec-driven-planning init
 # GitHub Copilot用に初期化
 npx spec-driven-planning init --github-copilot
 
+# Windsurf用に初期化
+npx spec-driven-planning init --windsurf
+
+# Codex用に初期化
+npx spec-driven-planning init --codex
+
 # 日本語で初期化
 npx spec-driven-planning init --lang ja
 
@@ -33,6 +39,8 @@ npx spec-driven-planning init --github-copilot --lang ja
 以下のファイル・ディレクトリが作成されます:
 - `.claude/commands/sdp/` - カスタムスラッシュコマンド（Claude Code）
 - `.github/prompts/` - プロンプトファイル（GitHub Copilot）
+- `.windsurf/workflows/` - ワークフローファイル（Windsurf）
+- `.codex/prompts/` - プロンプトファイル（Codex）
 - `.sdp/config/` - 設定ファイル（言語設定を含む）
 - `.sdp/templates/en/` - 英語ドキュメントテンプレート
 - `.sdp/templates/ja/` - 日本語ドキュメントテンプレート
@@ -328,7 +336,16 @@ PERT見積もり付きのタスク分解を作成:
 
 ```
 .claude/
-└── commands/sdp/       # カスタムスラッシュコマンド
+└── commands/sdp/       # カスタムスラッシュコマンド（Claude Code）
+
+.github/
+└── prompts/            # プロンプトファイル（GitHub Copilot）
+
+.windsurf/
+└── workflows/          # ワークフローファイル（Windsurf）
+
+.codex/
+└── prompts/            # プロンプトファイル（Codex）
 
 .sdp/                   # SDP作業ディレクトリ（gitignore対象）
 ├── config/             # 設定ファイル
@@ -369,28 +386,56 @@ language: ja  # 英語の場合は 'en'、日本語の場合は 'ja' に変更
 
 その後のすべてのコマンドは指定された言語でコンテンツを生成します。
 
-## GitHub Copilotサポート
+## マルチプラットフォームサポート
 
-SDPはClaude Codeに加えて、GitHub Copilotにも対応しました！初期化時に`--github-copilot`フラグを使用することで、GitHub Copilot用のプロンプトファイルをセットアップできます。
+SDPは複数のAIコーディングアシスタントをサポートしています！初期化時にプラットフォーム固有のフラグを使用してください。
 
-### GitHub Copilotのセットアップ
+### サポートされているプラットフォーム
 
-1. **GitHub Copilotサポートで初期化:**
-   ```bash
-   npx spec-driven-planning init --github-copilot
-   ```
+#### Claude Code（デフォルト）
+```bash
+npx spec-driven-planning init
+```
+`.claude/commands/sdp/`にカスタムスラッシュコマンドを配置
 
-2. **VS Codeでプロンプトファイルを有効化:**
-   - VS Code設定を開く（Cmd+, または Ctrl+,）
-   - `chat.promptFiles`を検索
-   - 設定を有効化
+#### GitHub Copilot
+```bash
+npx spec-driven-planning init --github-copilot
+```
 
-3. **VS Codeをリロード**してプロンプトファイルを有効化
+セットアップ手順:
+1. VS Code設定でプロンプトファイルを有効化（Cmd+, または Ctrl+,）
+2. `chat.promptFiles`を検索して有効化
+3. VS Codeをリロードしてプロンプトファイルを有効化
+
+`.github/prompts/`にプロンプトファイルを配置
+
+#### Windsurf
+```bash
+npx spec-driven-planning init --windsurf
+```
+
+セットアップ手順:
+1. Windsurfを再起動してワークフローファイルを有効化
+2. Windsurf Cascadeインターフェースからワークフローにアクセス
+
+`.windsurf/workflows/`にワークフローファイルを配置
+
+#### Codex
+```bash
+npx spec-driven-planning init --codex
+```
+
+セットアップ手順:
+1. Codexを再起動してプロンプトファイルを有効化
+2. Codexインターフェースからプロンプトにアクセス
+
+`.codex/prompts/`にプロンプトファイルを配置
 
 ### コマンドの違い
 
-| Claude Code | GitHub Copilot | 説明 |
-|------------|----------------|------|
+| Claude Code | GitHub Copilot / Windsurf / Codex | 説明 |
+|------------|-----------------------------------|------|
 | `/sdp:steering` | `/sdp-steering` | プロジェクトコンテキストを生成 |
 | `/sdp:requirement` | `/sdp-requirement` | 要件仕様を洗練化 |
 | `/sdp:pre-design` | `/sdp-pre-design` | 事前設計を生成 |
@@ -401,14 +446,14 @@ SDPはClaude Codeに加えて、GitHub Copilotにも対応しました！初期�
 | `/sdp:implement` | `/sdp-implement` | 実装タスクを実行 |
 | `/sdp:export-issues` | `/sdp-export-issues` | Issue Trackerへエクスポート |
 
-### GitHub Copilotでのプロンプトファイル使用方法
+### プロンプトファイルの使用方法
 
-GitHub Copilot Chatビューで:
+GitHub Copilot / Windsurf / Codexで:
 1. `/`に続けてコマンド名を入力
 2. 必要に応じて引数を追加（例: `/sdp-requirement ユーザー認証を追加`）
 3. Enterキーを押して実行
 
-GitHub Copilotはプロンプトファイルを使用し、Claude Codeと同じ構造化された出力を生成します！
+すべてのプラットフォームで同じ構造化された出力を生成します！
 
 ## 必要要件
 
@@ -416,6 +461,8 @@ GitHub Copilotはプロンプトファイルを使用し、Claude Codeと同じ�
 - **AIアシスタント**: 以下のいずれか:
   - **Claude Code**: `.claude/commands/sdp/`カスタムコマンド用
   - **GitHub Copilot**: `.github/prompts/`プロンプトファイル用（VS Codeで`chat.promptFiles`設定を有効化する必要があります）
+  - **Windsurf**: `.windsurf/workflows/`ワークフローファイル用
+  - **Codex**: `.codex/prompts/`プロンプトファイル用
 
 ### オプション要件（エクスポート先に応じて）
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ npx spec-driven-planning init
 # Initialize for GitHub Copilot
 npx spec-driven-planning init --github-copilot
 
+# Initialize for Windsurf
+npx spec-driven-planning init --windsurf
+
+# Initialize for Codex
+npx spec-driven-planning init --codex
+
 # Initialize with Japanese
 npx spec-driven-planning init --lang ja
 
@@ -35,6 +41,8 @@ npx spec-driven-planning init --github-copilot --lang ja
 This will create:
 - `.claude/commands/sdp/` - Custom slash commands (Claude Code)
 - `.github/prompts/` - Prompt files (GitHub Copilot)
+- `.windsurf/workflows/` - Workflow files (Windsurf)
+- `.codex/prompts/` - Prompt files (Codex)
 - `.sdp/config/` - Configuration files (including language settings)
 - `.sdp/templates/en/` - English document templates
 - `.sdp/templates/ja/` - Japanese document templates
@@ -329,7 +337,16 @@ Each template includes detailed examples and guidance.
 
 ```
 .claude/
-└── commands/sdp/       # Custom slash commands
+└── commands/sdp/       # Custom slash commands (Claude Code)
+
+.github/
+└── prompts/            # Prompt files (GitHub Copilot)
+
+.windsurf/
+└── workflows/          # Workflow files (Windsurf)
+
+.codex/
+└── prompts/            # Prompt files (Codex)
 
 .sdp/                   # SDP working directory (gitignored)
 ├── config/             # Configuration files
@@ -370,28 +387,56 @@ language: ja  # Change to 'en' for English or 'ja' for Japanese
 
 All subsequent commands will generate content in the specified language.
 
-## GitHub Copilot Support
+## Multi-Platform Support
 
-SDP now supports GitHub Copilot in addition to Claude Code! Use the `--github-copilot` flag during initialization to set up prompt files for GitHub Copilot.
+SDP supports multiple AI coding assistants! Use the platform-specific flag during initialization.
 
-### Setup for GitHub Copilot
+### Supported Platforms
 
-1. **Initialize with GitHub Copilot support:**
-   ```bash
-   npx spec-driven-planning init --github-copilot
-   ```
+#### Claude Code (Default)
+```bash
+npx spec-driven-planning init
+```
+Custom slash commands in `.claude/commands/sdp/`
 
-2. **Enable prompt files in VS Code:**
-   - Open VS Code Settings (Cmd+, or Ctrl+,)
-   - Search for `chat.promptFiles`
-   - Enable the setting
+#### GitHub Copilot
+```bash
+npx spec-driven-planning init --github-copilot
+```
 
-3. **Reload VS Code** to activate the prompt files
+Setup steps:
+1. Enable prompt files in VS Code Settings (Cmd+, or Ctrl+,)
+2. Search for `chat.promptFiles` and enable it
+3. Reload VS Code to activate the prompt files
+
+Prompt files in `.github/prompts/`
+
+#### Windsurf
+```bash
+npx spec-driven-planning init --windsurf
+```
+
+Setup steps:
+1. Restart Windsurf to activate workflow files
+2. Access workflows via the Windsurf Cascade interface
+
+Workflow files in `.windsurf/workflows/`
+
+#### Codex
+```bash
+npx spec-driven-planning init --codex
+```
+
+Setup steps:
+1. Restart Codex to activate prompt files
+2. Access prompts via the Codex interface
+
+Prompt files in `.codex/prompts/`
 
 ### Command Differences
 
-| Claude Code | GitHub Copilot | Description |
-|------------|----------------|-------------|
+| Claude Code | GitHub Copilot / Windsurf / Codex | Description |
+|------------|-----------------------------------|-------------|
 | `/sdp:steering` | `/sdp-steering` | Generate project context |
 | `/sdp:requirement` | `/sdp-requirement` | Refine requirement specification |
 | `/sdp:pre-design` | `/sdp-pre-design` | Generate pre-design |
@@ -402,14 +447,14 @@ SDP now supports GitHub Copilot in addition to Claude Code! Use the `--github-co
 | `/sdp:implement` | `/sdp-implement` | Execute implementation tasks |
 | `/sdp:export-issues` | `/sdp-export-issues` | Export to issue trackers |
 
-### Using Prompt Files in GitHub Copilot
+### Using Prompt Files
 
-In the GitHub Copilot Chat view:
+In GitHub Copilot / Windsurf / Codex:
 1. Type `/` followed by the command name
 2. Add arguments as needed (e.g., `/sdp-requirement Add user authentication`)
 3. Press Enter to execute
 
-GitHub Copilot will use the prompt file and generate the same structured outputs as Claude Code!
+All platforms generate the same structured outputs!
 
 ## Requirements
 
@@ -417,6 +462,8 @@ GitHub Copilot will use the prompt file and generate the same structured outputs
 - **AI Assistant**: One of the following:
   - **Claude Code**: For `.claude/commands/sdp/` custom commands
   - **GitHub Copilot**: For `.github/prompts/` prompt files (requires VS Code with `chat.promptFiles` setting enabled)
+  - **Windsurf**: For `.windsurf/workflows/` workflow files
+  - **Codex**: For `.codex/prompts/` prompt files
 
 ### Optional (for issue export)
 

--- a/bin/sdp.js
+++ b/bin/sdp.js
@@ -65,7 +65,8 @@ function showHelp() {
   log('Options:', colors.bright);
   log('  --lang <en|ja>        Set output language (default: en)');
   log('  --github-copilot      Setup for GitHub Copilot instead of Claude Code');
-  log('  --windsurf            Setup for Windsurf instead of Claude Code\n');
+  log('  --windsurf            Setup for Windsurf instead of Claude Code');
+  log('  --codex               Setup for Codex instead of Claude Code\n');
 }
 
 function showVersion() {
@@ -103,17 +104,19 @@ function main() {
       }
     }
 
-    // Parse GitHub Copilot and Windsurf options
+    // Parse GitHub Copilot, Windsurf, and Codex options
     const isGitHubCopilot = args.includes('--github-copilot');
     const isWindsurf = args.includes('--windsurf');
+    const isCodex = args.includes('--codex');
 
     // Check for conflicting options
-    if (isGitHubCopilot && isWindsurf) {
-      error('Cannot use both --github-copilot and --windsurf options together');
+    const optionCount = [isGitHubCopilot, isWindsurf, isCodex].filter(Boolean).length;
+    if (optionCount > 1) {
+      error('Cannot use multiple platform options together (--github-copilot, --windsurf, --codex)');
       process.exit(1);
     }
 
-    const targetType = isGitHubCopilot ? 'GitHub Copilot' : (isWindsurf ? 'Windsurf' : 'Claude Code');
+    const targetType = isGitHubCopilot ? 'GitHub Copilot' : (isWindsurf ? 'Windsurf' : (isCodex ? 'Codex' : 'Claude Code'));
 
     log('\n╔═══════════════════════════════════════════════════════════╗', colors.bright + colors.cyan);
     log('║                                                           ║', colors.bright + colors.cyan);
@@ -130,11 +133,13 @@ function main() {
       ? path.join(targetDir, '.github', 'prompts')
       : isWindsurf
         ? path.join(targetDir, '.windsurf', 'workflows')
-        : path.join(targetDir, '.claude', 'commands', 'sdp');
+        : isCodex
+          ? path.join(targetDir, '.codex', 'prompts')
+          : path.join(targetDir, '.claude', 'commands', 'sdp');
 
     // Check if commands directory already exists
     if (fs.existsSync(commandsDir)) {
-      const dirName = isGitHubCopilot ? '.github/prompts/' : (isWindsurf ? '.windsurf/workflows/' : '.claude/commands/sdp/');
+      const dirName = isGitHubCopilot ? '.github/prompts/' : (isWindsurf ? '.windsurf/workflows/' : (isCodex ? '.codex/prompts/' : '.claude/commands/sdp/'));
       warn(`${dirName} directory already exists.`);
       const readline = require('readline').createInterface({
         input: process.stdin,
@@ -147,14 +152,14 @@ function main() {
         if (answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes') {
           info(`Removing existing ${dirName} directory...`);
           fs.rmSync(commandsDir, { recursive: true, force: true });
-          setupSDP(targetDir, lang, isGitHubCopilot, isWindsurf);
+          setupSDP(targetDir, lang, isGitHubCopilot, isWindsurf, isCodex);
         } else {
           info('Setup cancelled. No changes were made.');
           process.exit(0);
         }
       });
     } else {
-      setupSDP(targetDir, lang, isGitHubCopilot, isWindsurf);
+      setupSDP(targetDir, lang, isGitHubCopilot, isWindsurf, isCodex);
     }
   } else {
     error(`Unknown command: ${command}`);
@@ -163,7 +168,7 @@ function main() {
   }
 }
 
-function setupSDP(targetDir, lang = 'en', isGitHubCopilot = false, isWindsurf = false) {
+function setupSDP(targetDir, lang = 'en', isGitHubCopilot = false, isWindsurf = false, isCodex = false) {
   const sourceDir = path.join(__dirname, '..');
   const sdpSourceDir = path.join(sourceDir, '.sdp');
   const sdpTargetDir = path.join(targetDir, '.sdp');
@@ -186,6 +191,13 @@ function setupSDP(targetDir, lang = 'en', isGitHubCopilot = false, isWindsurf = 
       info('📁 Copying .windsurf/workflows/ directory...');
       copyRecursive(windsurfWorkflowsSource, windsurfWorkflowsTarget);
       success('.windsurf/workflows/ directory created');
+    } else if (isCodex) {
+      // Copy Codex prompt files
+      const codexPromptsSource = path.join(sourceDir, '.codex', 'prompts');
+      const codexPromptsTarget = path.join(targetDir, '.codex', 'prompts');
+      info('📁 Copying .codex/prompts/ directory...');
+      copyRecursive(codexPromptsSource, codexPromptsTarget);
+      success('.codex/prompts/ directory created');
     } else {
       // Copy Claude Code commands
       const claudeCommandsSdpSource = path.join(sourceDir, '.claude', 'commands', 'sdp');
@@ -237,6 +249,8 @@ language: ${lang}
       log('   .github/prompts/         - GitHub Copilot prompt files');
     } else if (isWindsurf) {
       log('   .windsurf/workflows/     - Windsurf workflow files');
+    } else if (isCodex) {
+      log('   .codex/prompts/          - Codex prompt files');
     } else {
       log('   .claude/commands/sdp/    - Custom slash commands');
     }
@@ -253,12 +267,16 @@ language: ${lang}
       log('⚙️  Windsurf Setup:', colors.bright + colors.cyan);
       log('   1. Restart Windsurf to activate workflow files');
       log('   2. Access workflows via the Windsurf Cascade interface\n');
+    } else if (isCodex) {
+      log('⚙️  Codex Setup:', colors.bright + colors.cyan);
+      log('   1. Restart Codex to activate prompt files');
+      log('   2. Access prompts via the Codex interface\n');
     }
 
     log('🚀 Next Steps:', colors.bright + colors.cyan);
     log('   1. Review and customize .sdp/config/*.yml files');
     log('   2. Update repository settings in .sdp/config/export.yml');
-    if (isGitHubCopilot || isWindsurf) {
+    if (isGitHubCopilot || isWindsurf || isCodex) {
       log('   3. Run: /sdp-steering to initialize project context');
       log('   4. Start with: /sdp-requirement "Your requirement description"');
       log('   5. Generate tasks with: /sdp-estimate <slug>');
@@ -275,7 +293,7 @@ language: ${lang}
     }
 
     log('📖 Available Commands:', colors.bright + colors.cyan);
-    if (isGitHubCopilot || isWindsurf) {
+    if (isGitHubCopilot || isWindsurf || isCodex) {
       log('   /sdp-steering              - Generate project context');
       log('   /sdp-requirement <text>    - Refine requirement specification');
       log('   /sdp-design <slug>         - Generate detailed design with alternatives');

--- a/bin/sdp.js
+++ b/bin/sdp.js
@@ -3,7 +3,7 @@
 const fs = require('fs');
 const path = require('path');
 
-const VERSION = '1.8.0';
+const VERSION = '1.9.0';
 
 // ANSI color codes
 const colors = {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spec-driven-planning",
   "version": "1.8.0",
-  "description": "Spec-Driven Planning (SDP) CLI tool for Claude Code, GitHub Copilot, and Windsurf",
+  "description": "Spec-Driven Planning (SDP) CLI tool for Claude Code, GitHub Copilot, Windsurf, and Codex",
   "bin": {
     "sdp": "./bin/sdp.js"
   },
@@ -10,6 +10,7 @@
     ".claude/",
     ".github/",
     ".windsurf/",
+    ".codex/",
     ".sdp/",
     "README.md"
   ],
@@ -20,6 +21,7 @@
     "claude-code",
     "github-copilot",
     "windsurf",
+    "codex",
     "spec-driven-planning",
     "sdp",
     "requirements",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-driven-planning",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Spec-Driven Planning (SDP) CLI tool for Claude Code, GitHub Copilot, Windsurf, and Codex",
   "bin": {
     "sdp": "./bin/sdp.js"


### PR DESCRIPTION
This pull request adds comprehensive documentation and prompt files to support a Spec-Driven Planning (SDP) workflow with GitHub Copilot. The new prompt files enable Copilot to guide users through requirement refinement, design generation, task estimation, project planning, and issue export, all configurable for English or Japanese language output. The documentation explains setup, available commands, and usage examples.

**Documentation and Workflow Support:**

* Added `.codex/prompts/README.md` with instructions for setting up Copilot prompt files, command descriptions, and usage examples for SDP workflow.

**Prompt Files for SDP Workflow:**

* Requirement Refinement: Added `sdp-requirement.prompt.md` (listed in README) to guide Copilot in normalizing requirements.
* Design Generation:
  - Added `sdp-design-legacy.prompt.md` for generating design alternatives, comparison, and recommended solutions, supporting phased design document creation.
  - Added `sdp-design.prompt.md` for generating comprehensive, implementation-ready detailed design based on selected alternatives, with strict completeness and specificity guidelines.
* Task Estimation: Added `sdp-estimate.prompt.md` for decomposing requirements into tasks with PERT estimates, critical path analysis, and project rollup metrics.
* Issue Export: Added `sdp-export-issues.prompt.md` for exporting tasks to GitHub Issues, Jira, Backlog, or local markdown files, with configuration and output templates.

All prompt files include detailed instructions for context file usage, language configuration, pre-checks, and step-by-step guidance for their respective workflow stages.